### PR TITLE
fix: point GitHub link to repo instead of org

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -4,7 +4,7 @@ description: Quarkus Club is a community of developers passionate about modern J
 name: Quarkus Club
 simple-name: QuarkusClub
 image: quarkusclub.jpeg
-social-github: quarkusclub
+social-github: quarkusclub/quarkusclub.github.io
 social-discord: https://discord.gg/HvdXEZHU
 layout: index
 social-youtube: https://www.youtube.com/@QuarkusClub


### PR DESCRIPTION
## Summary

- Changes `social-github` in `content/index.html` from `quarkusclub` to `quarkusclub/quarkusclub.github.io`
- The home page GitHub button and footer links now resolve to `https://github.com/quarkusclub/quarkusclub.github.io` instead of `https://github.com/quarkusclub`

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)