### PR TITLE
Refactor color scheme and typography across the application

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -50,12 +50,15 @@ jobs:
           echo "pr_number=${{ github.event.number }}" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Publish blog to Surge.sh
-        run: |
-          # Deploy to a unique URL for this commit
-          npx surge ./target/roq --domain https://quarkusclub-blog-pr-${{ steps.pr.outputs.pr_number }}-${{ steps.pr.outputs.sha_short }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-          # Deploy to the latest URL for this PR
-          npx surge ./target/roq --domain https://quarkusclub-blog-pr-${{ steps.pr.outputs.pr_number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+    - name: Install Surge
+      run: npm install surge
+
+    - name: Publish blog to Surge.sh
+      run: |
+        # Deploy to a unique URL for this commit
+        npx surge ./target/roq --domain https://quarkusclub-blog-pr-${{ steps.pr.outputs.pr_number }}-${{ steps.pr.outputs.sha_short }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        # Deploy to the latest URL for this PR
+        npx surge ./target/roq --domain https://quarkusclub-blog-pr-${{ steps.pr.outputs.pr_number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Comment preview URL on PR
         uses: quarkusio/action-helpers@main

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -60,6 +60,15 @@ jobs:
         # Deploy to the latest URL for this PR
         npx surge ./target/roq --domain https://quarkusclub-blog-pr-${{ steps.pr.outputs.pr_number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
+    - name: Save commit SHA for teardown
+      run: echo "${{ steps.pr.outputs.sha_short }}" >> commit-shas.txt
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: pr-${{ steps.pr.outputs.pr_number }}-shas
+        path: commit-shas.txt
+        retention-days: 30
+
       - name: Comment preview URL on PR
         uses: quarkusio/action-helpers@main
         with:

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -18,8 +18,21 @@ jobs:
     - name: Install Surge
       run: npm install surge
 
-    - name: Teardown surge preview
-      id: deploy
+    - name: Download commit SHAs artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: pr-${{ github.event.number }}-shas
+      continue-on-error: true
+      id: download-shas
+
+    - name: Teardown commit-pinned surge previews
+      if: steps.download-shas.outcome == 'success'
+      run: |
+        while IFS= read -r sha; do
+          npx surge teardown "https://quarkusclub-blog-pr-${{ github.event.number }}-${sha}-preview.surge.sh" --token ${{ secrets.SURGE_TOKEN }} || true
+        done < commit-shas.txt
+
+    - name: Teardown latest surge preview
       run: npx surge teardown https://quarkusclub-blog-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment
         uses: actions-cool/maintain-one-comment@v3.2.0

--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -15,9 +15,12 @@ jobs:
   preview-teardown:
     runs-on: ubuntu-latest
     steps:
-      - name: Teardown surge preview
-        id: deploy
-        run: npx surge teardown https://quarkusclub-blog-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+    - name: Install Surge
+      run: npm install surge
+
+    - name: Teardown surge preview
+      id: deploy
+      run: npx surge teardown https://quarkusclub-blog-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment
         uses: actions-cool/maintain-one-comment@v3.2.0
         with:

--- a/content/bookclub.html
+++ b/content/bookclub.html
@@ -122,10 +122,10 @@ layout: page
         We're planning more book club initiatives. Stay tuned for announcements about our next book study sessions.
     </p>
     <div class="flex gap-4">
-        <a href="{site.url('/events')}" class="px-6 py-3 bg-[#b20738] text-white rounded-lg hover:bg-[#8a052c] transition-colors">
+          <a href="{site.url('/events')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-black hover:text-white hover:border-black transition-colors">
             View upcoming events
-        </a>
-        <a href="{site.url('/about')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-[#b20738] hover:text-white transition-colors">
+          </a>
+          <a href="{site.url('/about')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-black hover:text-white hover:border-black transition-colors">
             Join our community
         </a>
     </div>

--- a/content/bookclub.html
+++ b/content/bookclub.html
@@ -19,7 +19,7 @@ layout: page
         <div>
             <h2 class="text-3xl font-bold mb-2">Quarkus in Action</h2>
             <p class="text-gray-600 mb-4">
-                Study the book <a href="https://developers.redhat.com/e-books/quarkus-action" class="text-blue-600 hover:text-blue-800 underline" target="_blank">Quarkus in Action</a>
+                Study the book <a href="https://developers.redhat.com/e-books/quarkus-action" class="text-[#b20738] hover:text-[#8a052c] underline" target="_blank">Quarkus in Action</a>
                 with the authors Martin Stefanko and Jan Martiska. A great opportunity to learn Quarkus from core contributors!
             </p>
             <div class="flex gap-4 text-sm text-gray-500">
@@ -30,84 +30,84 @@ layout: page
     </div>
 
     <div class="space-y-8">
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 1</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/w3Sj8YhRzyU?si=PqSXpZ9W0ODrIGRL" title="Chapter 1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 2</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/8jb1iD8-_Us?si=TkaXBrJE5j7T5a8j" title="Chapter 2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 3</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/-cGxG7-D8e0?si=tB1ZyQgJLh3ePgJm" title="Chapter 3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 4</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/HqO6yf0-PgI?si=8S-tsoBDrBQqQDN2" title="Chapter 4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 5</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Kqdl3L69P5Q?si=Q6JPObmhGNVxCpv8" title="Chapter 5" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 6</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg"  src="https://www.youtube.com/embed/kWB3TJPuHcw?si=HXcBxmkdHDzdUA6D" title="Chapter 6" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 7</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg"  src="https://www.youtube.com/embed/ZybFGJVTnGg?si=VK8OUEgmESl-MsL9" title="Chapter 7" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 8</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/ZFhxDLuXLqY?si=H95TG1hLF4I2HA3W" title="Chapter 8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 9</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Q7PsUvWiBtU?si=hR5nXRz_z7RqJkva" title="Chapter 9" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 10</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/WiN2qbs7Rws?si=MnkXYBnfvofV6rwd" title="Chapter 10" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 11</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/pdMNO6ODnR0?si=R_NPYzAGScPH2Twi" title="Chapter 11" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
 
-        <div class="border-l-4 border-blue-600 pl-6">
+        <div class="border-l-4 border-[#b20738] pl-6">
             <h3 class="text-xl font-semibold mb-3">Chapter 12</h3>
             <div class="aspect-video max-w-3xl">
                 <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/jhr9UoAe6qM?si=GTTx91NeaaB4CVo5" title="Chapter 12" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -116,16 +116,16 @@ layout: page
 </section>
 
 <!-- Placeholder for future book clubs -->
-<section class="p-8 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg">
+<section class="p-8 bg-gradient-to-r from-gray-100 to-gray-200 rounded-lg">
     <h2 class="text-2xl font-bold mb-4 text-gray-900">More Book Clubs Coming Soon!</h2>
     <p class="text-gray-700 mb-4">
         We're planning more book club initiatives. Stay tuned for announcements about our next book study sessions.
     </p>
     <div class="flex gap-4">
-        <a href="{site.url('/events')}" class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+        <a href="{site.url('/events')}" class="px-6 py-3 bg-[#b20738] text-white rounded-lg hover:bg-[#8a052c] transition-colors">
             View upcoming events
         </a>
-        <a href="{site.url('/about')}" class="px-6 py-3 bg-white text-blue-600 border-2 border-blue-600 rounded-lg hover:bg-blue-600 hover:text-white transition-colors">
+        <a href="{site.url('/about')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-[#b20738] hover:text-white transition-colors">
             Join our community
         </a>
     </div>

--- a/content/bookclub.html
+++ b/content/bookclub.html
@@ -4,129 +4,130 @@ description: Join us in studying great books about Quarkus and Java development
 layout: page
 ---
 
-<div class="mb-12">
-    <h1 class="text-4xl font-bold mb-4">BookClub: Quarkus in Action</h1>
-    <p class="text-xl text-gray-600">
+<div class="mb-12 bg-surface-1 p-8 rounded-xl border border-border">
+    <div class="flex items-center gap-3 mb-4">
+        <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+        <h1 class="text-4xl font-bold mb-0! text-text-primary tracking-wider">BOOKCLUB: QUARKUS IN ACTION</h1>
+    </div>
+    <p class="text-xl text-text-secondary">
         Welcome to the Quarkus BookClub! Join our community in studying great books about Quarkus, Java, and software development.
         Learn from the authors themselves and connect with fellow developers.
     </p>
+
+    <!-- Quarkus in Action Book Club -->
+    <section class="mb-16 p-8 bg-surface-1 rounded-xl border border-border">
+        <div class="flex items-start gap-6 mb-6">
+            <img src="{site.image('duke-bookclub.png')}" alt="Quarkus in Action" class="w-32 h-auto rounded-lg shadow-md" />
+            <div>
+                <h2 class="text-3xl font-bold mb-2 text-text-primary">Quarkus in Action</h2>
+                <p class="text-text-secondary mb-4">
+                    Study the book <a href="https://developers.redhat.com/e-books/quarkus-action" class="text-brand-red hover:text-brand-red-light underline" target="_blank">Quarkus in Action</a>
+                    with the authors Martin Stefanko and Jan Martiska. A great opportunity to learn Quarkus from core contributors!
+                </p>
+                <div class="flex gap-4 text-sm text-text-muted">
+                    <span><i class="fa fa-users text-brand-red"></i> Authors: Martin Stefanko & Jan Martiska</span>
+                    <span><i class="fa fa-video text-brand-red"></i> 12 Chapters</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="space-y-8">
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 1</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/w3Sj8YhRzyU?si=PqSXpZ9W0ODrIGRL" title="Chapter 1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 2</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/8jb1iD8-_Us?si=TkaXBrJE5j7T5a8j" title="Chapter 2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 3</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/-cGxG7-D8e0?si=tB1ZyQgJLh3ePgJm" title="Chapter 3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 4</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/HqO6yf0-PgI?si=8S-tsoBDrBQqQDN2" title="Chapter 4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 5</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Kqdl3L69P5Q?si=Q6JPObmhGNVxCpv8" title="Chapter 5" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 6</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/kWB3TJPuHcw?si=HXcBxmkdHDzdUA6D" title="Chapter 6" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 7</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/ZybFGJVTnGg?si=VK8OUEgmESl-MsL9" title="Chapter 7" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 8</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/ZFhxDLuXLqY?si=H95TG1hLF4I2HA3W" title="Chapter 8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 9</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Q7PsUvWiBtU?si=hR5nXRz_z7RqJkva" title="Chapter 9" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 10</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/WiN2qbs7Rws?si=MnkXYBnfvofV6rwd" title="Chapter 10" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 11</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/pdMNO6ODnR0?si=R_NPYzAGScPH2Twi" title="Chapter 11" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+
+            <div class="border-l-4 border-brand-red pl-6">
+                <h3 class="text-xl font-semibold mb-3 text-text-primary">Chapter 12</h3>
+                <div class="aspect-video max-w-3xl">
+                    <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/jhr9UoAe6qM?si=GTTx91NeaaB4CVo5" title="Chapter 12" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Placeholder for future book clubs -->
+    <section class="p-8 bg-surface-2 rounded-lg border border-border text-center">
+        <h2 class="text-2xl font-bold mb-3 text-text-primary tracking-wider">MORE BOOK CLUBS COMING SOON!</h2>
+        <p class="text-text-secondary mb-6 max-w-xl mx-auto">
+            We're planning more book club initiatives. Stay tuned for announcements about our next book study sessions.
+        </p>
+        <div class="flex gap-4 justify-center">
+            <a href="{site.url('/events')}" class="inline-flex items-center gap-2 px-6 py-3 bg-brand-red rounded-lg font-semibold hover:bg-brand-red-light transition-colors no-underline" style="color:#fff">
+                <i class="fas fa-calendar-alt"></i>View upcoming events
+            </a>
+        </div>
+    </section>
 </div>
-
-<!-- Quarkus in Action Book Club -->
-<section class="mb-16 p-8 bg-white rounded-lg shadow-md">
-    <div class="flex items-start gap-6 mb-6">
-        <img src="{site.image('duke-bookclub.png')}" alt="Quarkus in Action" class="w-32 h-auto rounded-lg shadow-md" />
-        <div>
-            <h2 class="text-3xl font-bold mb-2">Quarkus in Action</h2>
-            <p class="text-gray-600 mb-4">
-                Study the book <a href="https://developers.redhat.com/e-books/quarkus-action" class="text-[#b20738] hover:text-[#8a052c] underline" target="_blank">Quarkus in Action</a>
-                with the authors Martin Stefanko and Jan Martiska. A great opportunity to learn Quarkus from core contributors!
-            </p>
-            <div class="flex gap-4 text-sm text-gray-500">
-                <span><i class="fa fa-users"></i> Authors: Martin Stefanko & Jan Martiska</span>
-                <span><i class="fa fa-video"></i> 12 Chapters</span>
-            </div>
-        </div>
-    </div>
-
-    <div class="space-y-8">
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 1</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/w3Sj8YhRzyU?si=PqSXpZ9W0ODrIGRL" title="Chapter 1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 2</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/8jb1iD8-_Us?si=TkaXBrJE5j7T5a8j" title="Chapter 2" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 3</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/-cGxG7-D8e0?si=tB1ZyQgJLh3ePgJm" title="Chapter 3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 4</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/HqO6yf0-PgI?si=8S-tsoBDrBQqQDN2" title="Chapter 4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 5</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Kqdl3L69P5Q?si=Q6JPObmhGNVxCpv8" title="Chapter 5" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 6</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg"  src="https://www.youtube.com/embed/kWB3TJPuHcw?si=HXcBxmkdHDzdUA6D" title="Chapter 6" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 7</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg"  src="https://www.youtube.com/embed/ZybFGJVTnGg?si=VK8OUEgmESl-MsL9" title="Chapter 7" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 8</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/ZFhxDLuXLqY?si=H95TG1hLF4I2HA3W" title="Chapter 8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 9</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/Q7PsUvWiBtU?si=hR5nXRz_z7RqJkva" title="Chapter 9" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 10</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/WiN2qbs7Rws?si=MnkXYBnfvofV6rwd" title="Chapter 10" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 11</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/pdMNO6ODnR0?si=R_NPYzAGScPH2Twi" title="Chapter 11" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>
-
-        <div class="border-l-4 border-[#b20738] pl-6">
-            <h3 class="text-xl font-semibold mb-3">Chapter 12</h3>
-            <div class="aspect-video max-w-3xl">
-                <iframe class="w-full h-full rounded-lg" src="https://www.youtube.com/embed/jhr9UoAe6qM?si=GTTx91NeaaB4CVo5" title="Chapter 12" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-        </div>        
-</section>
-
-<!-- Placeholder for future book clubs -->
-<section class="p-8 bg-gradient-to-r from-gray-100 to-gray-200 rounded-lg">
-    <h2 class="text-2xl font-bold mb-4 text-gray-900">More Book Clubs Coming Soon!</h2>
-    <p class="text-gray-700 mb-4">
-        We're planning more book club initiatives. Stay tuned for announcements about our next book study sessions.
-    </p>
-    <div class="flex gap-4">
-          <a href="{site.url('/events')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-black hover:text-white hover:border-black transition-colors">
-            View upcoming events
-          </a>
-          <a href="{site.url('/about')}" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-black hover:text-white hover:border-black transition-colors">
-            Join our community
-        </a>
-    </div>
-</section>

--- a/content/events.html
+++ b/content/events.html
@@ -15,63 +15,69 @@ layout: page
     <!-- Upcoming Events Section -->
     <section class="mb-16">
         <div class="flex items-center gap-3 mb-8">
-            <div class="w-1 h-8 bg-blue-600 rounded"></div>
-            <h2 class="text-3xl font-bold text-gray-900 m-0!">Upcoming events</h2>
+<div class="w-1 h-8 bg-[#b20738] rounded"></div>
+      <h2 class="text-3xl font-bold text-gray-900 m-0!">Upcoming events</h2>
         </div>
         
         {#if !future.isEmpty}
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {#for event in future.reversed}
             {#if !event.data.draft}
-            <article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group border-l-4 border-blue-600">
-                <div class="p-6">
-                    <div class="flex items-start justify-between mb-4">
-                        <span class="px-3 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">Upcoming</span>
-                        <i class="fas fa-calendar-alt text-blue-600 text-xl"></i>
-                    </div>
-                    
-                    <h3 class="text-xl font-bold mb-3 line-clamp-2">
-                        <a href="{event.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{event.title}</a>
-                    </h3>
-                    
-                    <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
-                        <i class="fa fa-calendar text-blue-600"></i>
-                        <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
-                        {#if event.data.language?? && event.data.language == 'pt-BR'}
-                        <span class="flex items-center gap-1" title="Portuguese (Brazil)">
-                            <span class="text-sm text-gray-600">Language:</span>
-                            <span class="text-sm font-semibold text-blue-600">pt-BR</span>
-                        </span>
-                        {/if}
-                    </div>
-                    
-                    {#if event.data.speakers?? && !event.data.speakers.isEmpty}
-                    <div class="border-t pt-4">
-                        <p class="text-sm text-gray-500 mb-2">Speakers:</p>
-                        <div class="flex flex-wrap gap-2">
-                            {#for id in event.data.speakers}
-                            {#let speaker = cdi:speakers.get(id)}
-                            {#if speaker.profile??}
-                            <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-blue-600 hover:text-blue-800 hover:underline">
-                                {speaker.name}
-                            </a>
-                            {#else}
-                            <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
-                            {/if}
-                            {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
-                            {/for}
-                        </div>
-                    </div>
-                    {/if}
-                </div>
-            </article>
+        <article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group border-l-4 border-[#b20738]">
+          <div class="p-6">
+            <div class="flex items-start justify-between mb-4">
+              <span class="px-3 py-1 bg-red-100 text-[#b20738] text-xs font-semibold rounded-full">Upcoming</span>
+              <i class="fas fa-calendar-alt text-[#b20738] text-xl"></i>
+            </div>
+
+            <h3 class="text-xl font-bold mb-3 line-clamp-2">
+              <a href="{event.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{event.title}</a>
+            </h3>
+
+            <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
+              <i class="fa fa-calendar text-[#b20738]"></i>
+              <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
+              {#if event.data.containsKey("youtubeLive")}
+              <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-gray-600 hover:text-[#b20738] transition-colors">
+                <i class="fab fa-youtube"></i>
+                <span>YouTube</span>
+              </a>
+              {/if}
+              {#if event.data.language?? && event.data.language == 'pt-BR'}
+              <span class="flex items-center gap-1" title="Portuguese (Brazil)">
+                <span class="text-sm text-gray-600">Language:</span>
+                <span class="text-sm font-semibold text-[#b20738]">pt-BR</span>
+              </span>
+              {/if}
+            </div>
+
+            {#if event.data.speakers?? && !event.data.speakers.isEmpty}
+            <div class="border-t pt-4">
+              <p class="text-sm text-gray-500 mb-2">Speakers:</p>
+              <div class="flex flex-wrap gap-2">
+                {#for id in event.data.speakers}
+                {#let speaker = cdi:speakers.get(id)}
+                {#if speaker.profile??}
+                <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-[#b20738] hover:text-[#8a052c] hover:underline">
+                  {speaker.name}
+                </a>
+                {#else}
+                <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
+                {/if}
+                {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
+                {/for}
+              </div>
+            </div>
+            {/if}
+          </div>
+        </article>
             {/if}
             {/for}
         </div>
         {#else}
-        <div class="bg-blue-50 border-l-4 border-blue-600 p-6 rounded-lg">
+        <div class="bg-gray-50 border-l-4 border-[#b20738] p-6 rounded-lg">
             <div class="flex items-center gap-3">
-                <i class="fas fa-info-circle text-blue-600 text-2xl"></i>
+                <i class="fas fa-info-circle text-[#b20738] text-2xl"></i>
                 <p class="text-gray-700">No upcoming events at the moment. Check back soon for new announcements!</p>
             </div>
         </div>
@@ -87,49 +93,55 @@ layout: page
         
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {#for event in site.collections.events.past}
-            <article class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all overflow-hidden group border-l-4 border-gray-400">
-                <div class="p-6">
-                    <div class="flex items-start justify-between mb-4">
-                        <span class="px-3 py-1 bg-gray-100 text-gray-700 text-xs font-semibold rounded-full">Past Event</span>
-                        <i class="fas fa-calendar-check text-gray-600 text-xl"></i>
-                    </div>
-                    
-                    <h3 class="text-xl font-bold mb-3 line-clamp-2">
-                        <a href="{event.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{event.title}</a>
-                    </h3>
-                    
-                    <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
-                        <i class="fa fa-calendar text-gray-600"></i>
-                        <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
-                        {#if event.data.language?? && event.data.language == 'pt-BR'}
-                        <span class="flex items-center gap-1" title="Portuguese (Brazil)">
-                            <span class="text-sm text-gray-600">Language:</span>
-                            <span class="text-2xl">🇧🇷</span>
-                            <span class="text-sm font-semibold text-gray-600">pt-BR</span>
-                        </span>
-                        {/if}
-                    </div>
-                    
-                    {#if event.data.speakers??}
-                    <div class="border-t pt-4">
-                        <p class="text-sm text-gray-500 mb-2">Speakers:</p>
-                        <div class="flex flex-wrap gap-2">
-                            {#for id in event.data.speakers}
-                            {#let speaker = cdi:speakers.get(id)}
-                            {#if speaker.profile??}
-                            <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-blue-600 hover:text-blue-800 hover:underline">
-                                {speaker.name}
-                            </a>
-                            {#else}
-                            <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
-                            {/if}
-                            {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
-                            {/for}
-                        </div>
-                    </div>
-                    {/if}
-                </div>
-            </article>
+        <article class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all overflow-hidden group border-l-4 border-gray-400">
+          <div class="p-6">
+            <div class="flex items-start justify-between mb-4">
+              <span class="px-3 py-1 bg-gray-100 text-gray-700 text-xs font-semibold rounded-full">Past Event</span>
+              <i class="fas fa-calendar-check text-gray-600 text-xl"></i>
+            </div>
+
+            <h3 class="text-xl font-bold mb-3 line-clamp-2">
+              <a href="{event.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{event.title}</a>
+            </h3>
+
+            <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
+              <i class="fa fa-calendar text-gray-600"></i>
+              <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
+              {#if event.data.containsKey("youtubeLive")}
+              <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-gray-600 hover:text-[#b20738] transition-colors">
+                <i class="fab fa-youtube"></i>
+                <span>YouTube</span>
+              </a>
+              {/if}
+              {#if event.data.language?? && event.data.language == 'pt-BR'}
+              <span class="flex items-center gap-1" title="Portuguese (Brazil)">
+                <span class="text-sm text-gray-600">Language:</span>
+                <span class="text-2xl">🇧🇷</span>
+                <span class="text-sm font-semibold text-gray-600">pt-BR</span>
+              </span>
+              {/if}
+            </div>
+
+            {#if event.data.speakers??}
+            <div class="border-t pt-4">
+              <p class="text-sm text-gray-500 mb-2">Speakers:</p>
+              <div class="flex flex-wrap gap-2">
+                {#for id in event.data.speakers}
+                {#let speaker = cdi:speakers.get(id)}
+                {#if speaker.profile??}
+                <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-[#b20738] hover:text-[#8a052c] hover:underline">
+                  {speaker.name}
+                </a>
+                {#else}
+                <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
+                {/if}
+                {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
+                {/for}
+              </div>
+            </div>
+            {/if}
+          </div>
+        </article>
             {/for}
         </div>
     </section>

--- a/content/events.html
+++ b/content/events.html
@@ -7,78 +7,81 @@ layout: page
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <!-- Page Header -->
-    <div class="mb-12">
-        <h1 class="text-4xl md:text-5xl font-bold mb-4 text-gray-900">Events</h1>
-        <p class="text-lg text-gray-600">Join our community events, meetups, and learning sessions</p>
+    <div class="mb-12 bg-surface-1 p-8 md:p-10 rounded-xl border border-border">
+        <div class="flex items-center gap-3 mb-4">
+            <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+            <h1 class="text-5xl md:text-6xl font-bold mb-0! text-text-primary tracking-wider">EVENTS</h1>
+        </div>
+        <p class="text-lg text-text-secondary">Join our community events, meetups, and learning sessions</p>
     </div>
 
     <!-- Upcoming Events Section -->
     <section class="mb-16">
         <div class="flex items-center gap-3 mb-8">
-<div class="w-1 h-8 bg-[#b20738] rounded"></div>
-      <h2 class="text-3xl font-bold text-gray-900 m-0!">Upcoming events</h2>
+            <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+            <h2 class="text-3xl font-bold text-text-primary m-0! tracking-wider">UPCOMING EVENTS</h2>
         </div>
-        
+
         {#if !future.isEmpty}
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {#for event in future.reversed}
             {#if !event.data.draft}
-        <article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group border-l-4 border-[#b20738]">
-          <div class="p-6">
-            <div class="flex items-start justify-between mb-4">
-              <span class="px-3 py-1 bg-red-100 text-[#b20738] text-xs font-semibold rounded-full">Upcoming</span>
-              <i class="fas fa-calendar-alt text-[#b20738] text-xl"></i>
-            </div>
+            <article class="bg-surface-1 rounded-xl border border-border hover:border-brand-red transition-all overflow-hidden group glow-red-hover">
+                <div class="p-6">
+                    <div class="flex items-start justify-between mb-4">
+                        <span class="px-3 py-1 bg-brand-red/20 text-brand-red text-xs font-semibold rounded-full border border-brand-red/30">Upcoming</span>
+                        <i class="fas fa-calendar-alt text-brand-red text-xl"></i>
+                    </div>
 
-            <h3 class="text-xl font-bold mb-3 line-clamp-2">
-              <a href="{event.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{event.title}</a>
-            </h3>
+                    <h3 class="text-xl font-bold mb-3 line-clamp-2">
+                        <a href="{event.url}" class="text-text-primary hover:text-brand-red transition-colors">{event.title}</a>
+                    </h3>
 
-            <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
-              <i class="fa fa-calendar text-[#b20738]"></i>
-              <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
-              {#if event.data.containsKey("youtubeLive")}
-              <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-gray-600 hover:text-[#b20738] transition-colors">
-                <i class="fab fa-youtube"></i>
-                <span>YouTube</span>
-              </a>
-              {/if}
-              {#if event.data.language?? && event.data.language == 'pt-BR'}
-              <span class="flex items-center gap-1" title="Portuguese (Brazil)">
-                <span class="text-sm text-gray-600">Language:</span>
-                <span class="text-sm font-semibold text-[#b20738]">pt-BR</span>
-              </span>
-              {/if}
-            </div>
+                    <div class="flex items-center gap-2 text-sm text-text-secondary mb-4">
+                        <i class="fa fa-calendar text-brand-red"></i>
+                        <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
+                        {#if event.data.containsKey("youtubeLive")}
+                        <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-text-secondary hover:text-brand-red transition-colors">
+                            <i class="fab fa-youtube"></i>
+                            <span>YouTube</span>
+                        </a>
+                        {/if}
+                        {#if event.data.language?? && event.data.language == 'pt-BR'}
+                        <span class="flex items-center gap-1" title="Portuguese (Brazil)">
+                            <span class="text-sm text-text-muted">Language:</span>
+                            <span class="text-sm font-semibold text-brand-red">pt-BR</span>
+                        </span>
+                        {/if}
+                    </div>
 
-            {#if event.data.speakers?? && !event.data.speakers.isEmpty}
-            <div class="border-t pt-4">
-              <p class="text-sm text-gray-500 mb-2">Speakers:</p>
-              <div class="flex flex-wrap gap-2">
-                {#for id in event.data.speakers}
-                {#let speaker = cdi:speakers.get(id)}
-                {#if speaker.profile??}
-                <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-[#b20738] hover:text-[#8a052c] hover:underline">
-                  {speaker.name}
-                </a>
-                {#else}
-                <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
-                {/if}
-                {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
-                {/for}
-              </div>
-            </div>
-            {/if}
-          </div>
-        </article>
+                    {#if event.data.speakers?? && !event.data.speakers.isEmpty}
+                    <div class="border-t border-border pt-4">
+                        <p class="text-sm text-text-muted mb-2">Speakers:</p>
+                        <div class="flex flex-wrap gap-2">
+                            {#for id in event.data.speakers}
+                            {#let speaker = cdi:speakers.get(id)}
+                            {#if speaker.profile??}
+                            <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline">
+                                {speaker.name}
+                            </a>
+                            {#else}
+                            <span class="text-sm font-semibold text-text-secondary">{speaker.name}</span>
+                            {/if}
+                            {#if id_hasNext}<span class="text-text-muted">•</span>{/if}
+                            {/for}
+                        </div>
+                    </div>
+                    {/if}
+                </div>
+            </article>
             {/if}
             {/for}
         </div>
         {#else}
-        <div class="bg-gray-50 border-l-4 border-[#b20738] p-6 rounded-lg">
+        <div class="bg-surface-1 border-l-4 border-brand-red p-6 rounded-lg border border-border">
             <div class="flex items-center gap-3">
-                <i class="fas fa-info-circle text-[#b20738] text-2xl"></i>
-                <p class="text-gray-700">No upcoming events at the moment. Check back soon for new announcements!</p>
+                <i class="fas fa-info-circle text-brand-red text-2xl"></i>
+                <p class="text-text-secondary">No upcoming events at the moment. Check back soon for new announcements!</p>
             </div>
         </div>
         {/if}
@@ -87,63 +90,62 @@ layout: page
     <!-- Past Events Section -->
     <section class="mb-16">
         <div class="flex items-center gap-3 mb-8">
-            <div class="w-1 h-8 bg-gray-600 rounded"></div>
-            <h2 class="text-3xl font-bold text-gray-900 m-0!">Past events</h2>
+            <div class="w-1.5 h-8 bg-text-muted rounded"></div>
+            <h2 class="text-3xl font-bold text-text-primary m-0! tracking-wider">PAST EVENTS</h2>
         </div>
-        
+
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {#for event in site.collections.events.past}
-        <article class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all overflow-hidden group border-l-4 border-gray-400">
-          <div class="p-6">
-            <div class="flex items-start justify-between mb-4">
-              <span class="px-3 py-1 bg-gray-100 text-gray-700 text-xs font-semibold rounded-full">Past Event</span>
-              <i class="fas fa-calendar-check text-gray-600 text-xl"></i>
-            </div>
+            <article class="bg-surface-1 rounded-xl border border-border hover:border-text-muted transition-all overflow-hidden group">
+                <div class="p-6">
+                    <div class="flex items-start justify-between mb-4">
+                        <span class="px-3 py-1 bg-surface-3 text-text-muted text-xs font-semibold rounded-full border border-border">Past Event</span>
+                        <i class="fas fa-calendar-check text-text-muted text-xl"></i>
+                    </div>
 
-            <h3 class="text-xl font-bold mb-3 line-clamp-2">
-              <a href="{event.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{event.title}</a>
-            </h3>
+                    <h3 class="text-xl font-bold mb-3 line-clamp-2">
+                        <a href="{event.url}" class="text-text-primary hover:text-brand-red transition-colors">{event.title}</a>
+                    </h3>
 
-            <div class="flex items-center gap-2 text-sm text-gray-600 mb-4">
-              <i class="fa fa-calendar text-gray-600"></i>
-              <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
-              {#if event.data.containsKey("youtubeLive")}
-              <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-gray-600 hover:text-[#b20738] transition-colors">
-                <i class="fab fa-youtube"></i>
-                <span>YouTube</span>
-              </a>
-              {/if}
-              {#if event.data.language?? && event.data.language == 'pt-BR'}
-              <span class="flex items-center gap-1" title="Portuguese (Brazil)">
-                <span class="text-sm text-gray-600">Language:</span>
-                <span class="text-2xl">🇧🇷</span>
-                <span class="text-sm font-semibold text-gray-600">pt-BR</span>
-              </span>
-              {/if}
-            </div>
+                    <div class="flex items-center gap-2 text-sm text-text-secondary mb-4">
+                        <i class="fa fa-calendar text-text-muted"></i>
+                        <span>{event.date.format(global:FULL_DATE_FORMAT)}</span>
+                        {#if event.data.containsKey("youtubeLive")}
+                        <a href="{event.data.youtubeLive}" target="_blank" class="flex items-center gap-1 text-text-secondary hover:text-brand-red transition-colors">
+                            <i class="fab fa-youtube"></i>
+                            <span>YouTube</span>
+                        </a>
+                        {/if}
+                        {#if event.data.language?? && event.data.language == 'pt-BR'}
+                        <span class="flex items-center gap-1" title="Portuguese (Brazil)">
+                            <span class="text-sm text-text-muted">Language:</span>
+                            <span class="text-2xl">🇧🇷</span>
+                            <span class="text-sm font-semibold text-text-muted">pt-BR</span>
+                        </span>
+                        {/if}
+                    </div>
 
-            {#if event.data.speakers??}
-            <div class="border-t pt-4">
-              <p class="text-sm text-gray-500 mb-2">Speakers:</p>
-              <div class="flex flex-wrap gap-2">
-                {#for id in event.data.speakers}
-                {#let speaker = cdi:speakers.get(id)}
-                {#if speaker.profile??}
-                <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-[#b20738] hover:text-[#8a052c] hover:underline">
-                  {speaker.name}
-                </a>
-                {#else}
-                <span class="text-sm font-semibold text-gray-700">{speaker.name}</span>
-                {/if}
-                {#if id_hasNext}<span class="text-gray-400">•</span>{/if}
-                {/for}
-              </div>
-            </div>
-            {/if}
-          </div>
-        </article>
+                    {#if event.data.speakers??}
+                    <div class="border-t border-border pt-4">
+                        <p class="text-sm text-text-muted mb-2">Speakers:</p>
+                        <div class="flex flex-wrap gap-2">
+                            {#for id in event.data.speakers}
+                            {#let speaker = cdi:speakers.get(id)}
+                            {#if speaker.profile??}
+                            <a href="{speaker.profile}" target="_blank" class="text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline">
+                                {speaker.name}
+                            </a>
+                            {#else}
+                            <span class="text-sm font-semibold text-text-secondary">{speaker.name}</span>
+                            {/if}
+                            {#if id_hasNext}<span class="text-text-muted">•</span>{/if}
+                            {/for}
+                        </div>
+                    </div>
+                    {/if}
+                </div>
+            </article>
             {/for}
         </div>
     </section>
 </div>
-

--- a/content/posts.html
+++ b/content/posts.html
@@ -21,7 +21,7 @@ paginate: posts
             {/if}
             <div class="p-4 sm:p-6">
                 <h2 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-                    <a href="{post.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{post.title}</a>
+                    <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
                 </h2>
                 {#if post.description??}
                 <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
@@ -29,7 +29,7 @@ paginate: posts
                 <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
                     {#if post.date??}
                     <span class="flex items-center gap-1 whitespace-nowrap">
-                        <i class="fa fa-calendar text-blue-600 text-xs"></i>
+                        <i class="fa fa-calendar text-[#b20738] text-xs"></i>
                         {post.date.format(global:FULL_DATE_FORMAT)}
                     </span>
                     {/if}

--- a/content/posts.html
+++ b/content/posts.html
@@ -5,36 +5,40 @@ layout: main
 paginate: posts
 ---
 
-<div class="max-w-7xl mx-auto">
-    <div class="mb-12">
-        <h1 class="text-4xl md:text-5xl font-bold mb-4 text-gray-900">Blog Posts</h1>
-        <p class="text-lg text-gray-600">Explore all our articles about Quarkus, Java, and modern development practices.</p>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="mb-12 bg-surface-1 p-8 md:p-10 rounded-xl border border-border">
+        <div class="flex items-center gap-3 mb-4">
+            <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+            <h1 class="text-5xl md:text-6xl font-bold mb-0! text-text-primary tracking-wider">BLOG POSTS</h1>
+        </div>
+        <p class="text-lg text-text-secondary">Explore all our articles about Quarkus, Java, and modern development practices.</p>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
         {#for post in site.collections.posts}
-        <article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group transform hover:-translate-y-1 duration-300">
+        <article class="bg-surface-1 rounded-xl border border-border hover:border-brand-red transition-all overflow-hidden group transform hover:-translate-y-1 duration-300 glow-red-hover">
             {#if post.image??}
-            <div class="overflow-hidden h-40 sm:h-48">
+            <div class="overflow-hidden h-40 sm:h-48 relative">
                 <img src="{post.image}" alt="{post.title}" class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"/>
+                <div class="absolute inset-0 bg-gradient-to-t from-surface-1 via-transparent to-transparent"></div>
             </div>
             {/if}
             <div class="p-4 sm:p-6">
                 <h2 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-                    <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
+                    <a href="{post.url}" class="text-text-primary hover:text-brand-red transition-colors">{post.title}</a>
                 </h2>
                 {#if post.description??}
-                <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
+                <p class="text-sm sm:text-base text-text-secondary mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
                 {/if}
-                <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
+                <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-text-muted">
                     {#if post.date??}
                     <span class="flex items-center gap-1 whitespace-nowrap">
-                        <i class="fa fa-calendar text-[#b20738] text-xs"></i>
+                        <i class="fa fa-calendar text-brand-red text-xs"></i>
                         {post.date.format(global:FULL_DATE_FORMAT)}
                     </span>
                     {/if}
                     <span class="flex items-center gap-1 whitespace-nowrap">
-                        <i class="fa fa-clock text-green-600 text-xs"></i>
+                        <i class="fa fa-clock text-brand-red/60 text-xs"></i>
                         {post.readTime} min read
                     </span>
                 </div>

--- a/content/tags.html
+++ b/content/tags.html
@@ -8,19 +8,19 @@ layout: page
     <!-- Tags List with Details -->
     <div class="mb-12">
         <h2 class="text-2xl font-bold mb-6 text-gray-900 flex items-center gap-3">
-            <i class="fas fa-list text-blue-600"></i>
+            <i class="fas fa-list text-[#b20738]"></i>
             All Tags
         </h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {#for tag in site.collections.posts.tagsCount}
             <a href="{site.url('/posts/tag/')}{tag.name}" 
-               class="bg-white rounded-lg shadow-md hover:shadow-xl transition-all p-5 group border-l-4 border-blue-600 hover:border-blue-700 transform hover:-translate-y-1 duration-300">
+               class="bg-white rounded-lg shadow-md hover:shadow-xl transition-all p-5 group border-l-4 border-[#b20738] hover:border-[#8a052c] transform hover:-translate-y-1 duration-300">
                 <div class="flex items-center justify-between mb-2">
-                    <h3 class="text-lg font-bold text-gray-900 group-hover:text-blue-600 transition-colors flex items-center gap-2">
-                        <i class="fas fa-tag text-blue-600 text-sm"></i>
+                    <h3 class="text-lg font-bold text-gray-900 group-hover:text-[#b20738] transition-colors flex items-center gap-2">
+                        <i class="fas fa-tag text-[#b20738] text-sm"></i>
                         {tag.name}
                     </h3>
-                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+                    <span class="px-3 py-1 bg-red-100 text-[#8a052c] rounded-full text-sm font-bold">
                         {tag.count}
                     </span>
                 </div>
@@ -31,7 +31,7 @@ layout: page
                     {tag.count} posts available
                     {/if}
                 </p>
-                <div class="mt-3 flex items-center text-blue-600 group-hover:text-blue-700 text-sm font-semibold">
+                <div class="mt-3 flex items-center text-[#b20738] group-hover:text-[#8a052c] text-sm font-semibold">
                     View posts
                     <i class="fas fa-arrow-right ml-2 transform group-hover:translate-x-1 transition-transform"></i>
                 </div>
@@ -44,7 +44,7 @@ layout: page
     <div class="bg-gradient-to-r from-gray-50 to-gray-100 p-6 rounded-xl shadow-md">
         <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
             <div class="flex items-center gap-3">
-                <i class="fas fa-compass text-blue-600 text-2xl"></i>
+                <i class="fas fa-compass text-[#b20738] text-2xl"></i>
                 <div>
                     <h3 class="font-bold text-gray-900">Looking for something specific?</h3>
                     <p class="text-sm text-gray-600">Browse all our posts or events</p>
@@ -52,7 +52,7 @@ layout: page
             </div>
             <div class="flex gap-3">
                 <a href="{site.url('/posts')}" 
-                   class="px-5 py-2.5 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-all transform hover:scale-105 shadow-md text-sm">
+                   class="px-5 py-2.5 bg-[#b20738] text-white rounded-lg font-semibold hover:bg-[#8a052c] transition-all transform hover:scale-105 shadow-md text-sm">
                     <i class="fas fa-blog mr-2"></i>All Posts
                 </a>
                 <a href="{site.url('/events')}" 

--- a/content/tags.html
+++ b/content/tags.html
@@ -4,34 +4,34 @@ description: Browse all topics and categories from QuarkusClub
 layout: page
 ---
 
-<div class="max-w-7xl mx-auto">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <!-- Tags List with Details -->
     <div class="mb-12">
-        <h2 class="text-2xl font-bold mb-6 text-gray-900 flex items-center gap-3">
-            <i class="fas fa-list text-[#b20738]"></i>
+        <h2 class="text-2xl font-bold mb-6 text-text-primary flex items-center gap-3">
+            <i class="fas fa-list text-brand-red"></i>
             All Tags
         </h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {#for tag in site.collections.posts.tagsCount}
-            <a href="{site.url('/posts/tag/')}{tag.name}" 
-               class="bg-white rounded-lg shadow-md hover:shadow-xl transition-all p-5 group border-l-4 border-[#b20738] hover:border-[#8a052c] transform hover:-translate-y-1 duration-300">
+            <a href="{site.url('/posts/tag/')}{tag.name}"
+               class="bg-surface-1 rounded-lg border border-border hover:border-brand-red transition-all p-5 group border-l-4 border-brand-red hover:border-brand-red-light transform hover:-translate-y-1 duration-300">
                 <div class="flex items-center justify-between mb-2">
-                    <h3 class="text-lg font-bold text-gray-900 group-hover:text-[#b20738] transition-colors flex items-center gap-2">
-                        <i class="fas fa-tag text-[#b20738] text-sm"></i>
+                    <h3 class="text-lg font-bold text-text-primary group-hover:text-brand-red transition-colors flex items-center gap-2">
+                        <i class="fas fa-tag text-brand-red text-sm"></i>
                         {tag.name}
                     </h3>
-                    <span class="px-3 py-1 bg-red-100 text-[#8a052c] rounded-full text-sm font-bold">
+                    <span class="px-3 py-1 bg-brand-red/20 text-brand-red-light rounded-full text-sm font-bold">
                         {tag.count}
                     </span>
                 </div>
-                <p class="text-sm text-gray-600">
+                <p class="text-sm text-text-secondary">
                     {#if tag.count == 1}
                     1 post available
                     {#else}
                     {tag.count} posts available
                     {/if}
                 </p>
-                <div class="mt-3 flex items-center text-[#b20738] group-hover:text-[#8a052c] text-sm font-semibold">
+                <div class="mt-3 flex items-center text-brand-red group-hover:text-brand-red-light text-sm font-semibold">
                     View posts
                     <i class="fas fa-arrow-right ml-2 transform group-hover:translate-x-1 transition-transform"></i>
                 </div>
@@ -41,22 +41,22 @@ layout: page
     </div>
 
     <!-- Quick Navigation -->
-    <div class="bg-gradient-to-r from-gray-50 to-gray-100 p-6 rounded-xl shadow-md">
+    <div class="bg-surface-1 p-6 rounded-xl border border-border">
         <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
             <div class="flex items-center gap-3">
-                <i class="fas fa-compass text-[#b20738] text-2xl"></i>
+                <i class="fas fa-compass text-brand-red text-2xl"></i>
                 <div>
-                    <h3 class="font-bold text-gray-900">Looking for something specific?</h3>
-                    <p class="text-sm text-gray-600">Browse all our posts or events</p>
+                    <h3 class="font-bold text-text-primary">Looking for something specific?</h3>
+                    <p class="text-sm text-text-secondary">Browse all our posts or events</p>
                 </div>
             </div>
             <div class="flex gap-3">
-                <a href="{site.url('/posts')}" 
-                   class="px-5 py-2.5 bg-[#b20738] text-white rounded-lg font-semibold hover:bg-[#8a052c] transition-all transform hover:scale-105 shadow-md text-sm">
+                <a href="{site.url('/posts')}"
+                   class="px-5 py-2.5 bg-brand-red text-white rounded-lg font-semibold hover:bg-brand-red-light hover:text-white transition-all transform hover:scale-105 text-sm">
                     <i class="fas fa-blog mr-2"></i>All Posts
                 </a>
-                <a href="{site.url('/events')}" 
-                   class="px-5 py-2.5 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all transform hover:scale-105 shadow-md text-sm">
+                <a href="{site.url('/events')}"
+                   class="px-5 py-2.5 bg-surface-2 text-text-primary border border-border rounded-lg font-semibold hover:bg-surface-3 transition-all transform hover:scale-105 text-sm">
                     <i class="fas fa-calendar-alt mr-2"></i>Events
                 </a>
             </div>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,6 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
-          <dependency>
-            <groupId>org.mvnpm.at.fontsource</groupId>
-            <artifactId>atkinson-hyperlegible</artifactId>
-            <version>5.2.8</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>highlight.js</artifactId>

--- a/src/main/resources/web/app/app.js
+++ b/src/main/resources/web/app/app.js
@@ -1,4 +1,3 @@
-import "@fontsource/atkinson-hyperlegible";
 import hljs from 'highlight.js';
 import 'highlight.js/styles/tokyo-night-dark.min.css';
 

--- a/src/main/resources/web/app/styles.css
+++ b/src/main/resources/web/app/styles.css
@@ -1,2 +1,199 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+
+/* Google Fonts - Open Sans & Hanken Grotesk are loaded via CDN in default.html
+   Font weights available:
+   - Open Sans: 400, 600, 700, 800
+   - Hanken Grotesk: 400, 500, 600, 700
+*/
+
+/* ============================================
+   QUARKUS CLUB BRAND VARIABLES
+   ============================================ */
+:root {
+  /* Typography */
+  --font-heading: 'Open Sans', system-ui, -apple-system, sans-serif;
+  --font-body: 'Hanken Grotesk', system-ui, -apple-system, sans-serif;
+
+  /* Brand Colors - Quarkus Club Social Media Palette */
+  --color-white: #ffffff;
+  --color-light-gray: #d6d6d6;
+  --color-brand-red: #b20738;
+  --color-black: #000000;
+
+  /* Extended Brand Palette */
+  --color-brand-red-light: #d41a4a;
+  --color-brand-red-dark: #8a052c;
+  --color-gray-medium: #888888;
+  --color-gray-dark: #333333;
+  --color-off-white: #f5f5f5;
+
+  /* Semantic Color Mapping */
+  --color-primary: var(--color-brand-red);
+  --color-primary-hover: var(--color-brand-red-dark);
+  --color-primary-light: var(--color-brand-red-light);
+  --color-text-primary: var(--color-black);
+  --color-text-secondary: var(--color-gray-dark);
+  --color-text-muted: var(--color-gray-medium);
+  --color-background: var(--color-white);
+  --color-background-alt: var(--color-off-white);
+  --color-border: var(--color-light-gray);
+
+  /* Component-specific colors */
+  --color-header-bg: var(--color-black);
+  --color-header-text: var(--color-white);
+  --color-footer-bg: var(--color-black);
+  --color-footer-text: var(--color-white);
+  --color-link: var(--color-brand-red);
+  --color-link-hover: var(--color-brand-red-dark);
+  --color-button-primary-bg: var(--color-brand-red);
+  --color-button-primary-text: var(--color-white);
+  --color-button-secondary-bg: var(--color-black);
+  --color-button-secondary-text: var(--color-white);
+}
+
+/* Base styles */
+html {
+  font-family: var(--font-body);
+}
+
+/* Headings - Open Sans */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+}
+
+h1 {
+  font-weight: 800;
+}
+
+h2, h3 {
+  font-weight: 700;
+}
+
+h4, h5, h6 {
+  font-weight: 600;
+}
+
+/* Body text - Hanken Grotesk */
+body {
+  font-family: var(--font-body);
+}
+
+p, span, li, td, th, label, input, textarea, select, button {
+  font-family: var(--font-body);
+}
+
+/* Subheadings - Hanken Grotesk with medium weight */
+.subheading, .subtitle, .lead {
+  font-family: var(--font-body);
+  font-weight: 500;
+}
+
+/* Site title in header - Open Sans */
+header a.text-xl,
+header a.text-2xl,
+.brand, .site-title {
+  font-family: var(--font-heading);
+  font-weight: 700;
+}
+
+/* Navigation items - Hanken Grotesk */
+nav a, .nav-item, .menu-item {
+  font-family: var(--font-body);
+  font-weight: 500;
+}
+
+/* ============================================
+   BRAND COLOR UTILITY CLASSES
+   ============================================ */
+
+/* Background Colors */
+.bg-brand-red { background-color: var(--color-brand-red); }
+.bg-brand-red-light { background-color: var(--color-brand-red-light); }
+.bg-brand-red-dark { background-color: var(--color-brand-red-dark); }
+.bg-light-gray { background-color: var(--color-light-gray); }
+.bg-off-white { background-color: var(--color-off-white); }
+
+/* Text Colors */
+.text-brand-red { color: var(--color-brand-red); }
+.text-brand-red-light { color: var(--color-brand-red-light); }
+.text-brand-red-dark { color: var(--color-brand-red-dark); }
+.text-light-gray { color: var(--color-light-gray); }
+.text-gray-medium { color: var(--color-gray-medium); }
+.text-gray-dark { color: var(--color-gray-dark); }
+
+/* Border Colors */
+.border-brand-red { border-color: var(--color-brand-red); }
+.border-light-gray { border-color: var(--color-light-gray); }
+
+/* Hover States */
+.hover\:bg-brand-red-dark:hover { background-color: var(--color-brand-red-dark); }
+.hover\:text-brand-red:hover { color: var(--color-brand-red); }
+.hover\:text-brand-red-dark:hover { color: var(--color-brand-red-dark); }
+.hover\:border-brand-red:hover { border-color: var(--color-brand-red); }
+
+/* Link Styles using Brand Colors */
+a {
+  color: var(--color-link);
+  transition: color 0.2s ease-in-out;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+/* Button Primary - Brand Red */
+.btn-primary {
+  background-color: var(--color-button-primary-bg);
+  color: var(--color-button-primary-text);
+  font-family: var(--font-heading);
+  font-weight: 600;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.btn-primary:hover {
+  background-color: var(--color-brand-red-dark);
+}
+
+/* Button Secondary - Black */
+.btn-secondary {
+  background-color: var(--color-button-secondary-bg);
+  color: var(--color-button-secondary-text);
+  font-family: var(--font-body);
+  font-weight: 500;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-gray-dark);
+}
+
+/* Section-specific Branding */
+.section-events { --section-accent: var(--color-brand-red); }
+.section-bookclub { --section-accent: var(--color-brand-red); }
+.section-about { --section-accent: var(--color-brand-red); }
+
+/* Header Branding */
+header {
+  background-color: var(--color-header-bg);
+  color: var(--color-header-text);
+}
+
+header a {
+  color: var(--color-header-text);
+}
+
+header a:hover {
+  color: var(--color-brand-red-light);
+}
+
+/* Footer Branding */
+footer {
+  background-color: var(--color-footer-bg);
+  color: var(--color-footer-text);
+}
+
+/* Accent elements */
+.accent-border { border-left: 4px solid var(--color-brand-red); }
+.accent-text { color: var(--color-brand-red); }
+.accent-bg { background-color: var(--color-brand-red); }

--- a/src/main/resources/web/app/styles.css
+++ b/src/main/resources/web/app/styles.css
@@ -1,199 +1,161 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Google Fonts - Open Sans & Hanken Grotesk are loaded via CDN in default.html
-   Font weights available:
-   - Open Sans: 400, 600, 700, 800
-   - Hanken Grotesk: 400, 500, 600, 700
-*/
+@theme {
+  --font-display: 'Bebas Neue', system-ui, sans-serif;
+  --font-heading: 'Open Sans', system-ui, sans-serif;
+  --font-body: 'Hanken Grotesk', system-ui, sans-serif;
 
-/* ============================================
-   QUARKUS CLUB BRAND VARIABLES
-   ============================================ */
-:root {
-  /* Typography */
-  --font-heading: 'Open Sans', system-ui, -apple-system, sans-serif;
-  --font-body: 'Hanken Grotesk', system-ui, -apple-system, sans-serif;
-
-  /* Brand Colors - Quarkus Club Social Media Palette */
-  --color-white: #ffffff;
-  --color-light-gray: #d6d6d6;
   --color-brand-red: #b20738;
-  --color-black: #000000;
-
-  /* Extended Brand Palette */
   --color-brand-red-light: #d41a4a;
   --color-brand-red-dark: #8a052c;
-  --color-gray-medium: #888888;
-  --color-gray-dark: #333333;
-  --color-off-white: #f5f5f5;
+  --color-accent-warm: #c43a1c;
+  --color-accent-cool: #8a1a4a;
+  --color-discord: #5865F2;
+  --color-discord-dark: #4752C4;
 
-  /* Semantic Color Mapping */
-  --color-primary: var(--color-brand-red);
-  --color-primary-hover: var(--color-brand-red-dark);
-  --color-primary-light: var(--color-brand-red-light);
-  --color-text-primary: var(--color-black);
-  --color-text-secondary: var(--color-gray-dark);
-  --color-text-muted: var(--color-gray-medium);
-  --color-background: var(--color-white);
-  --color-background-alt: var(--color-off-white);
-  --color-border: var(--color-light-gray);
-
-  /* Component-specific colors */
-  --color-header-bg: var(--color-black);
-  --color-header-text: var(--color-white);
-  --color-footer-bg: var(--color-black);
-  --color-footer-text: var(--color-white);
-  --color-link: var(--color-brand-red);
-  --color-link-hover: var(--color-brand-red-dark);
-  --color-button-primary-bg: var(--color-brand-red);
-  --color-button-primary-text: var(--color-white);
-  --color-button-secondary-bg: var(--color-black);
-  --color-button-secondary-text: var(--color-white);
+  --color-base: #000000;
+  --color-surface-1: #1a1a1a;
+  --color-surface-2: #262626;
+  --color-surface-3: #333333;
+  --color-border: #3a3a3a;
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #d6d6d6;
+  --color-text-muted: #9a9a9a;
 }
 
-/* Base styles */
-html {
-  font-family: var(--font-body);
+@layer base {
+  html {
+    font-family: var(--font-body);
+    color: var(--color-text-secondary);
+    background-color: var(--color-base);
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  h1 {
+    font-family: var(--font-display);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  h2, h3, h4, h5, h6 {
+    font-family: var(--font-heading);
+  }
+
+  h2, h3 {
+    font-weight: 700;
+  }
+
+  h4, h5, h6 {
+    font-weight: 600;
+  }
+
+  .subheading, .subtitle, .lead {
+    font-family: var(--font-body);
+    font-weight: 500;
+  }
+
+  header a.text-xl,
+  header a.text-2xl,
+  .brand, .site-title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+  }
+
+  nav a, .nav-item, .menu-item {
+    font-family: var(--font-body);
+    font-weight: 500;
+  }
+
+  nav a:hover,
+  footer a:hover {
+    opacity: 0.8;
+  }
 }
 
-/* Headings - Open Sans */
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading);
+@layer components {
+  .prose {
+    color: var(--color-text-secondary);
+  }
+
+  .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+    color: var(--color-text-primary);
+  }
+
+  .prose a:not(.text-white) {
+    color: var(--color-brand-red-light);
+    text-decoration: underline;
+  }
+
+  .prose a:not(.text-white):hover {
+    color: var(--color-brand-red);
+  }
+
+  .prose strong {
+    color: var(--color-text-primary);
+  }
+
+  .prose code {
+    color: var(--color-text-primary);
+  }
+
+  .prose blockquote {
+    color: var(--color-text-muted);
+  }
 }
 
-h1 {
-  font-weight: 800;
+@layer utilities {
+  .text-text-secondary {
+    color: var(--color-text-secondary) !important;
+  }
+
+  .text-text-primary {
+    color: var(--color-text-primary) !important;
+  }
+
+  .text-text-muted {
+    color: var(--color-text-muted) !important;
+  }
+
+  .glow-red {
+    box-shadow: 0 0 12px rgba(178, 7, 56, 0.08),
+      0 0 40px rgba(178, 7, 56, 0.03);
+  }
+
+  .glow-red-hover:hover {
+    box-shadow: 0 0 16px rgba(178, 7, 56, 0.12),
+      0 0 50px rgba(178, 7, 56, 0.05);
+  }
+
+  .noise-bg {
+    position: relative;
+  }
+
+  .noise-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    opacity: 0.03;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 256px 256px;
+    border-radius: inherit;
+  }
+
+  .line-accent::before {
+    content: '';
+    display: inline-block;
+    width: 4px;
+    height: 100%;
+    background: var(--color-brand-red);
+    border-radius: 2px;
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
 }
-
-h2, h3 {
-  font-weight: 700;
-}
-
-h4, h5, h6 {
-  font-weight: 600;
-}
-
-/* Body text - Hanken Grotesk */
-body {
-  font-family: var(--font-body);
-}
-
-p, span, li, td, th, label, input, textarea, select, button {
-  font-family: var(--font-body);
-}
-
-/* Subheadings - Hanken Grotesk with medium weight */
-.subheading, .subtitle, .lead {
-  font-family: var(--font-body);
-  font-weight: 500;
-}
-
-/* Site title in header - Open Sans */
-header a.text-xl,
-header a.text-2xl,
-.brand, .site-title {
-  font-family: var(--font-heading);
-  font-weight: 700;
-}
-
-/* Navigation items - Hanken Grotesk */
-nav a, .nav-item, .menu-item {
-  font-family: var(--font-body);
-  font-weight: 500;
-}
-
-/* ============================================
-   BRAND COLOR UTILITY CLASSES
-   ============================================ */
-
-/* Background Colors */
-.bg-brand-red { background-color: var(--color-brand-red); }
-.bg-brand-red-light { background-color: var(--color-brand-red-light); }
-.bg-brand-red-dark { background-color: var(--color-brand-red-dark); }
-.bg-light-gray { background-color: var(--color-light-gray); }
-.bg-off-white { background-color: var(--color-off-white); }
-
-/* Text Colors */
-.text-brand-red { color: var(--color-brand-red); }
-.text-brand-red-light { color: var(--color-brand-red-light); }
-.text-brand-red-dark { color: var(--color-brand-red-dark); }
-.text-light-gray { color: var(--color-light-gray); }
-.text-gray-medium { color: var(--color-gray-medium); }
-.text-gray-dark { color: var(--color-gray-dark); }
-
-/* Border Colors */
-.border-brand-red { border-color: var(--color-brand-red); }
-.border-light-gray { border-color: var(--color-light-gray); }
-
-/* Hover States */
-.hover\:bg-brand-red-dark:hover { background-color: var(--color-brand-red-dark); }
-.hover\:text-brand-red:hover { color: var(--color-brand-red); }
-.hover\:text-brand-red-dark:hover { color: var(--color-brand-red-dark); }
-.hover\:border-brand-red:hover { border-color: var(--color-brand-red); }
-
-/* Link Styles using Brand Colors */
-a {
-  color: var(--color-link);
-  transition: color 0.2s ease-in-out;
-}
-
-a:hover {
-  color: var(--color-link-hover);
-}
-
-/* Button Primary - Brand Red */
-.btn-primary {
-  background-color: var(--color-button-primary-bg);
-  color: var(--color-button-primary-text);
-  font-family: var(--font-heading);
-  font-weight: 600;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.btn-primary:hover {
-  background-color: var(--color-brand-red-dark);
-}
-
-/* Button Secondary - Black */
-.btn-secondary {
-  background-color: var(--color-button-secondary-bg);
-  color: var(--color-button-secondary-text);
-  font-family: var(--font-body);
-  font-weight: 500;
-  transition: background-color 0.2s ease-in-out;
-}
-
-.btn-secondary:hover {
-  background-color: var(--color-gray-dark);
-}
-
-/* Section-specific Branding */
-.section-events { --section-accent: var(--color-brand-red); }
-.section-bookclub { --section-accent: var(--color-brand-red); }
-.section-about { --section-accent: var(--color-brand-red); }
-
-/* Header Branding */
-header {
-  background-color: var(--color-header-bg);
-  color: var(--color-header-text);
-}
-
-header a {
-  color: var(--color-header-text);
-}
-
-header a:hover {
-  color: var(--color-brand-red-light);
-}
-
-/* Footer Branding */
-footer {
-  background-color: var(--color-footer-bg);
-  color: var(--color-footer-text);
-}
-
-/* Accent elements */
-.accent-border { border-left: 4px solid var(--color-brand-red); }
-.accent-text { color: var(--color-brand-red); }
-.accent-bg { background-color: var(--color-brand-red); }

--- a/templates/layouts/404.html
+++ b/templates/layouts/404.html
@@ -15,10 +15,10 @@ layout: main
 
     
     <div class="flex gap-4 justify-center mb-12">
-        <a href="{site.url}" class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors inline-flex items-center gap-2">
+        <a href="{site.url}" class="px-6 py-3 bg-[#b20738] text-white rounded-lg hover:bg-[#8a052c] transition-colors inline-flex items-center gap-2">
             <i class="fa fa-home"></i> Go to Homepage
         </a>
-        <a href="javascript:history.back()" class="px-6 py-3 bg-white text-blue-600 border-2 border-blue-600 rounded-lg hover:bg-blue-600 hover:text-white transition-colors inline-flex items-center gap-2">
+        <a href="javascript:history.back()" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-[#b20738] hover:text-white transition-colors inline-flex items-center gap-2">
             <i class="fa fa-arrow-left"></i> Go Back
         </a>
     </div>

--- a/templates/layouts/404.html
+++ b/templates/layouts/404.html
@@ -2,23 +2,22 @@
 layout: main
 ---
 <div class="text-center py-16 max-w-4xl mx-auto">
-    <div class="text-red-500 text-6xl mb-6">
+    <div class="text-brand-red text-6xl mb-6">
         <i class="fa fa-exclamation-triangle"></i>
     </div>
-    
-    <h1 class="text-9xl font-bold text-gray-900 mb-4">404</h1>
-    <h2 class="text-3xl font-semibold text-gray-700 mb-4">Page Not Found</h2>
-    
-    <p class="text-xl text-gray-600 mb-8">
+
+    <h1 class="text-9xl font-bold text-text-primary mb-4">404</h1>
+    <h2 class="text-3xl font-semibold text-text-secondary mb-4">Page Not Found</h2>
+
+    <p class="text-xl text-text-muted mb-8">
         Oops! The page you're looking for doesn't exist or has been moved.
     </p>
 
-    
     <div class="flex gap-4 justify-center mb-12">
-        <a href="{site.url}" class="px-6 py-3 bg-[#b20738] text-white rounded-lg hover:bg-[#8a052c] transition-colors inline-flex items-center gap-2">
+        <a href="{site.url}" class="px-6 py-3 bg-brand-red text-white rounded-lg hover:bg-brand-red-light hover:text-white transition-colors inline-flex items-center gap-2 glow-red">
             <i class="fa fa-home"></i> Go to Homepage
         </a>
-        <a href="javascript:history.back()" class="px-6 py-3 bg-white text-[#b20738] border-2 border-[#b20738] rounded-lg hover:bg-[#b20738] hover:text-white transition-colors inline-flex items-center gap-2">
+        <a href="javascript:history.back()" class="px-6 py-3 bg-surface-1 text-brand-red border-2 border-brand-red rounded-lg hover:bg-brand-red hover:text-white transition-colors inline-flex items-center gap-2">
             <i class="fa fa-arrow-left"></i> Go Back
         </a>
     </div>

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -6,6 +6,10 @@
     <title>{page.title ?: site.title}</title>
     {#seo page site /}
     {#rss site /}
+    <!-- Google Fonts - Quarkus Club Brand Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=Open+Sans:wght@400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/output.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     {#bundle /}

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -6,15 +6,14 @@
     <title>{page.title ?: site.title}</title>
     {#seo page site /}
     {#rss site /}
-    <!-- Google Fonts - Quarkus Club Brand Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=Open+Sans:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Hanken+Grotesk:wght@400;500;600;700&family=Open+Sans:wght@400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/output.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     {#bundle /}
 </head>
-<body class="bg-gray-50">
+<body class="bg-base noise-bg">
     {#insert /}
 </body>
 </html>

--- a/templates/layouts/event.html
+++ b/templates/layouts/event.html
@@ -4,11 +4,11 @@ id: event
 ---
 <div class="w-full max-w-none px-3 sm:px-4 lg:px-6">
     <!-- Event Header -->
-    <div class="bg-gradient-to-r from-blue-600 to-blue-800 text-white rounded-xl p-6 sm:p-8 md:p-12 mb-8 shadow-xl">
+    <div class="bg-black text-white rounded-xl p-6 sm:p-8 md:p-12 mb-8 shadow-xl">
         <div class="flex flex-col md:flex-row items-center gap-6 mb-6">
             <img alt="Quarkus Club logo" class="w-24 h-24 md:w-32 md:h-32 rounded-full border-4 border-white shadow-lg" src="{site.image('quarkusclub.jpeg')}"/>
             <div class="flex-1 text-center md:text-left">
-                <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-4">{page.title}</h1>
+                <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 text-white!">{page.title}</h1>
                 <div class="flex items-center justify-center md:justify-start gap-2 text-lg">
                     <i class="fa fa-calendar-alt"></i>
                     <span>{page.date.format(global:FULL_DATE_FORMAT)}</span>
@@ -20,23 +20,23 @@ id: event
         <div class="flex flex-wrap justify-center md:justify-start gap-3">
 
             {#if page.data.containsKey("googleForms") && page.date.isAfterNow}
-            <a href="{page.data.googleForms}" target="_blank" class="px-6 py-3 bg-white text-blue-600 rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2 no-underline">
+            <a href="{page.data.googleForms}" target="_blank" class="px-6 py-3 bg-white text-[#b20738] rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2 no-underline">
                 <i class="fab fa-google"></i>
                 Register
             </a>
             {/if}
 
             {#if page.data.containsKey("subscription") && page.date.isAfterNow}
-            <a href="{page.data.subscription}" target="_blank" class="px-6 py-3 bg-white text-blue-600 rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
+            <a href="{page.data.subscription}" target="_blank" class="px-6 py-3 bg-white text-[#b20738] rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
                 <i class="fas fa-user-plus"></i>
                 Join Us
             </a>
             {/if}
 
             {#if page.data.containsKey("youtubeLive")}
-            <a href="{page.data.youtubeLive}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base inline-flex items-center gap-2">
-                <i class="fab fa-youtube"></i>YouTube
-            </a>
+        <a href="{page.data.youtubeLive}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base inline-flex items-center gap-2">
+          <i class="fab fa-youtube"></i>YouTube
+        </a>
             {/if}
 
             {#if page.data.containsKey("googleDriveSlides")}
@@ -52,7 +52,7 @@ id: event
     {#if page.description??}
     <section class="bg-white rounded-xl shadow-md p-6 md:p-8 mb-8">
         <div class="flex flex-row items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-blue-600 rounded"></div>
+            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
             <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">About this event</h2>
         </div>
         <div class="prose prose-lg max-w-none text-gray-700 [&>*:first-child]:mt-0">
@@ -64,14 +64,14 @@ id: event
     <!-- Speakers Section -->
     <section class="bg-white rounded-xl shadow-md p-6 md:p-8 mb-8">
         <div class="flex items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-blue-600 rounded"></div>
+            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
             <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">Speakers</h2>
         </div>
         
         {#if page.data.speakers.asStrings.isEmpty}
-        <div class="bg-blue-50 border-l-4 border-blue-600 p-6 rounded-lg">
+        <div class="bg-gray-50 border-l-4 border-[#b20738] p-6 rounded-lg">
             <div class="flex items-center gap-3">
-                <i class="fas fa-info-circle text-blue-600 text-2xl"></i>
+                <i class="fas fa-info-circle text-[#b20738] text-2xl"></i>
                 <p class="text-gray-700 font-medium">Speakers coming soon!</p>
             </div>
         </div>
@@ -79,10 +79,10 @@ id: event
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             {#for id in page.data.speakers}
             {#let speaker = cdi:speakers.get(id)}
-            <div class="bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg p-6 border-l-4 border-blue-600 hover:shadow-lg transition-shadow w-full">
+            <div class="bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg p-6 border-l-4 border-[#b20738] hover:shadow-lg transition-shadow w-full">
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-4">
-                        <div class="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center flex-shrink-0">
+                        <div class="w-12 h-12 bg-[#b20738] rounded-full flex items-center justify-center flex-shrink-0">
                             <i class="fas fa-user text-white text-xl"></i>
                         </div>
                         <h3 class="text-xl font-bold text-gray-900 m-0!">{speaker.name}</h3>
@@ -92,7 +92,7 @@ id: event
                         <p class="text-gray-700 text-sm leading-relaxed mb-3">{speaker.bio}</p>
                         {/if}
                         {#if speaker.profile??}
-                        <a href="{speaker.profile}" target="_blank" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 font-semibold text-sm">
+                        <a href="{speaker.profile}" target="_blank" class="inline-flex items-center gap-2 text-[#b20738] hover:text-[#8a052c] font-semibold text-sm">
                             <i class="fas fa-external-link-alt"></i>
                             View Profile
                         </a>
@@ -108,7 +108,7 @@ id: event
     <!-- Comments Section -->
     <section class="bg-white rounded-xl shadow-md p-6 md:p-8">
         <div class="flex items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-blue-600 rounded"></div>
+            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
             <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">Discussion</h2>
         </div>
         <script src="https://giscus.app/client.js"

--- a/templates/layouts/event.html
+++ b/templates/layouts/event.html
@@ -3,44 +3,41 @@ layout: page
 id: event
 ---
 <div class="w-full max-w-none px-3 sm:px-4 lg:px-6">
-    <!-- Event Header -->
-    <div class="bg-black text-white rounded-xl p-6 sm:p-8 md:p-12 mb-8 shadow-xl">
+    <div class="bg-surface-1 text-text-primary rounded-xl p-6 sm:p-8 md:p-12 mb-8 border border-border">
         <div class="flex flex-col md:flex-row items-center gap-6 mb-6">
-            <img alt="Quarkus Club logo" class="w-24 h-24 md:w-32 md:h-32 rounded-full border-4 border-white shadow-lg" src="{site.image('quarkusclub.jpeg')}"/>
+            <img alt="Quarkus Club logo" class="w-24 h-24 md:w-32 md:h-32 rounded-full border-4 border-brand-red shadow-lg" src="{site.image('quarkusclub.jpeg')}"/>
             <div class="flex-1 text-center md:text-left">
-                <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 text-white!">{page.title}</h1>
-                <div class="flex items-center justify-center md:justify-start gap-2 text-lg">
-                    <i class="fa fa-calendar-alt"></i>
+                <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-4">{page.title}</h1>
+                <div class="flex items-center justify-center md:justify-start gap-2 text-lg text-text-secondary">
+                    <i class="fa fa-calendar-alt text-brand-red"></i>
                     <span>{page.date.format(global:FULL_DATE_FORMAT)}</span>
                 </div>
             </div>
         </div>
 
-        <!-- Action Buttons -->
         <div class="flex flex-wrap justify-center md:justify-start gap-3">
-
             {#if page.data.containsKey("googleForms") && page.date.isAfterNow}
-            <a href="{page.data.googleForms}" target="_blank" class="px-6 py-3 bg-white text-[#b20738] rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2 no-underline">
+            <a href="{page.data.googleForms}" target="_blank" class="px-6 py-3 bg-brand-red text-white rounded-lg font-semibold hover:bg-brand-red-light hover:text-white transition-all transform hover:scale-105 shadow-lg flex items-center gap-2 no-underline">
                 <i class="fab fa-google"></i>
                 Register
             </a>
             {/if}
 
             {#if page.data.containsKey("subscription") && page.date.isAfterNow}
-            <a href="{page.data.subscription}" target="_blank" class="px-6 py-3 bg-white text-[#b20738] rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
+            <a href="{page.data.subscription}" target="_blank" class="px-6 py-3 bg-brand-red text-white rounded-lg font-semibold hover:bg-brand-red-light hover:text-white transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
                 <i class="fas fa-user-plus"></i>
                 Join Us
             </a>
             {/if}
 
             {#if page.data.containsKey("youtubeLive")}
-        <a href="{page.data.youtubeLive}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base inline-flex items-center gap-2">
-          <i class="fab fa-youtube"></i>YouTube
-        </a>
+            <a href="{page.data.youtubeLive}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-brand-red text-white rounded-lg font-semibold hover:bg-brand-red-light hover:text-white transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base inline-flex items-center gap-2">
+                <i class="fab fa-youtube"></i>YouTube
+            </a>
             {/if}
 
             {#if page.data.containsKey("googleDriveSlides")}
-            <a href="{page.data.googleDriveSlides}" target="_blank" class="px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
+            <a href="{page.data.googleDriveSlides}" target="_blank" class="px-6 py-3 bg-accent-warm text-white rounded-lg font-semibold hover:bg-accent-warm/80 transition-all transform hover:scale-105 shadow-lg flex items-center gap-2">
                 <i class="fab fa-google-drive"></i>
                 Slides
             </a>
@@ -48,51 +45,49 @@ id: event
         </div>
     </div>
 
-    <!-- Event Description -->
     {#if page.description??}
-    <section class="bg-white rounded-xl shadow-md p-6 md:p-8 mb-8">
+    <section class="bg-surface-1 rounded-xl border border-border p-6 md:p-8 mb-8">
         <div class="flex flex-row items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
-            <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">About this event</h2>
+            <div class="w-1 h-8 bg-brand-red rounded"></div>
+            <h2 class="text-2xl md:text-3xl font-bold text-text-primary m-0!">About this event</h2>
         </div>
-        <div class="prose prose-lg max-w-none text-gray-700 [&>*:first-child]:mt-0">
+        <div class="prose prose-lg prose-invert max-w-none text-text-secondary [&>*:first-child]:mt-0">
             {page.description.markdownify()}
         </div>
     </section>
     {/if}
 
-    <!-- Speakers Section -->
-    <section class="bg-white rounded-xl shadow-md p-6 md:p-8 mb-8">
+    <section class="bg-surface-1 rounded-xl border border-border p-6 md:p-8 mb-8">
         <div class="flex items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
-            <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">Speakers</h2>
+            <div class="w-1 h-8 bg-brand-red rounded"></div>
+            <h2 class="text-2xl md:text-3xl font-bold text-text-primary m-0!">Speakers</h2>
         </div>
-        
+
         {#if page.data.speakers.asStrings.isEmpty}
-        <div class="bg-gray-50 border-l-4 border-[#b20738] p-6 rounded-lg">
+        <div class="bg-surface-2 border-l-4 border-brand-red p-6 rounded-lg">
             <div class="flex items-center gap-3">
-                <i class="fas fa-info-circle text-[#b20738] text-2xl"></i>
-                <p class="text-gray-700 font-medium">Speakers coming soon!</p>
+                <i class="fas fa-info-circle text-brand-red text-2xl"></i>
+                <p class="text-text-secondary font-medium">Speakers coming soon!</p>
             </div>
         </div>
         {#else}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             {#for id in page.data.speakers}
             {#let speaker = cdi:speakers.get(id)}
-            <div class="bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg p-6 border-l-4 border-[#b20738] hover:shadow-lg transition-shadow w-full">
+            <div class="bg-surface-2 rounded-lg p-6 border-l-4 border-brand-red hover:border-brand-red-light hover:shadow-lg transition-all w-full">
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-4">
-                        <div class="w-12 h-12 bg-[#b20738] rounded-full flex items-center justify-center flex-shrink-0">
+                        <div class="w-12 h-12 bg-brand-red rounded-full flex items-center justify-center flex-shrink-0 glow-red">
                             <i class="fas fa-user text-white text-xl"></i>
                         </div>
-                        <h3 class="text-xl font-bold text-gray-900 m-0!">{speaker.name}</h3>
+                        <h3 class="text-xl font-bold text-text-primary m-0!">{speaker.name}</h3>
                     </div>
                     <div class="w-full">
                         {#if speaker.bio??}
-                        <p class="text-gray-700 text-sm leading-relaxed mb-3">{speaker.bio}</p>
+                        <p class="text-text-secondary text-sm leading-relaxed mb-3">{speaker.bio}</p>
                         {/if}
                         {#if speaker.profile??}
-                        <a href="{speaker.profile}" target="_blank" class="inline-flex items-center gap-2 text-[#b20738] hover:text-[#8a052c] font-semibold text-sm">
+                        <a href="{speaker.profile}" target="_blank" class="inline-flex items-center gap-2 text-brand-red hover:text-brand-red-light font-semibold text-sm">
                             <i class="fas fa-external-link-alt"></i>
                             View Profile
                         </a>
@@ -105,27 +100,26 @@ id: event
         {/if}
     </section>
 
-    <!-- Comments Section -->
-    <section class="bg-white rounded-xl shadow-md p-6 md:p-8">
+    <section class="bg-surface-1 rounded-xl border border-border p-6 md:p-8">
         <div class="flex items-center gap-3 mb-6">
-            <div class="w-1 h-8 bg-[#b20738] rounded"></div>
-            <h2 class="text-2xl md:text-3xl font-bold text-gray-900 m-0!">Discussion</h2>
+            <div class="w-1 h-8 bg-brand-red rounded"></div>
+            <h2 class="text-2xl md:text-3xl font-bold text-text-primary m-0!">Discussion</h2>
         </div>
         <script src="https://giscus.app/client.js"
-                data-repo="quarkusclub/quarkusclub.github.io"
-                data-repo-id="R_kgDOOjCTSg"
-                data-category="General"
-                data-category-id="DIC_kwDOOjCTSs4Cs8t7"
-                data-mapping="pathname"
-                data-strict="0"
-                data-reactions-enabled="1"
-                data-emit-metadata="0"
-                data-input-position="top"
-                data-theme="light"
-                data-lang="en"
-                data-loading="lazy"
-                crossorigin="anonymous"
-                async>
+            data-repo="quarkusclub/quarkusclub.github.io"
+            data-repo-id="R_kgDOOjCTSg"
+            data-category="General"
+            data-category-id="DIC_kwDOOjCTSs4Cs8t7"
+            data-mapping="pathname"
+            data-strict="0"
+            data-reactions-enabled="1"
+            data-emit-metadata="0"
+            data-input-position="top"
+            data-theme="dark"
+            data-lang="en"
+            data-loading="lazy"
+            crossorigin="anonymous"
+            async>
         </script>
     </section>
 </div>

--- a/templates/layouts/index.html
+++ b/templates/layouts/index.html
@@ -7,7 +7,7 @@ image: quarkusclub.jpg
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <!-- Hero Section -->
     <section class="relative py-12 sm:py-16 md:py-20 mb-12 md:mb-16 overflow-hidden">
-        <div class="absolute inset-0 bg-gradient-to-br from-blue-600 via-blue-700 to-blue-900 rounded-b-2xl"></div>
+        <div class="absolute inset-0 bg-black rounded-b-2xl"></div>
         <div class="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmYiIGZpbGwtb3BhY2l0eT0iMC4xIj48cGF0aCBkPSJNMzYgMzRjMC0yLjIxLTEuNzktNC00LTRzLTQgMS43OS00IDQgMS43OSA0IDQgNCA0LTEuNzkgNC00em0wLTEwYzAtMi4yMS0xLjc5LTQtNC00cy00IDEuNzktNCA0IDEuNzkgNCA0IDQgNC0xLjc5IDQtNHptMC0xMGMwLTIuMjEtMS43OS00LTQtNHMtNCAxLjc5LTQgNCAxLjc5IDQgNCA0IDQtMS43OSA0LTR6Ii8+PC9nPjwvZz48L3N2Zz4=')] opacity-20"></div>
         <div class="relative text-center text-white px-4 sm:px-6">
             <div class="mb-4 sm:mb-6">
@@ -20,21 +20,21 @@ image: quarkusclub.jpg
             <p class="text-base sm:text-lg md:text-xl lg:text-2xl max-w-3xl mx-auto mb-6 sm:mb-8 leading-relaxed">{page.description}</p>
             {/if}
             <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-3 sm:gap-4 mb-6 sm:mb-8">
-                {#if page.data('social-github')??}
-                <a href="https://github.com/{page.data('social-github')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-blue-600 rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-                    <i class="fab fa-github mr-2"></i>GitHub
-                </a>
-                {/if}
-                {#if page.data('social-discord')??}
-                <a href="{page.data('social-discord')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-                    <i class="fab fa-discord mr-2"></i>Discord
-                </a>
-                {/if}
-                {#if page.data('social-youtube')??}
-                <a href="{page.data('social-youtube')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-                    <i class="fab fa-youtube mr-2"></i>YouTube
-                </a>
-                {/if}
+      {#if page.data('social-github')??}
+      <a href="https://github.com/{page.data('social-github')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
+        <i class="fab fa-github mr-2"></i>GitHub
+      </a>
+      {/if}
+      {#if page.data('social-discord')??}
+      <a href="{page.data('social-discord')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
+        <i class="fab fa-discord mr-2"></i>Discord
+      </a>
+      {/if}
+      {#if page.data('social-youtube')??}
+      <a href="{page.data('social-youtube')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
+        <i class="fab fa-youtube mr-2"></i>YouTube
+      </a>
+      {/if}
             </div>
         </div>
     </section>
@@ -42,27 +42,27 @@ image: quarkusclub.jpg
     <!-- Features Section -->
     <section class="mb-12 md:mb-16">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
-            <div class="bg-gradient-to-br from-blue-50 to-blue-100 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-                <div class="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mb-4">
-                    <i class="fas fa-users text-white text-2xl"></i>
-                </div>
-                <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Community Driven</h3>
-                <p class="text-sm md:text-base text-gray-700">Join a vibrant community of developers passionate about Quarkus and modern Java development.</p>
-            </div>
-            <div class="bg-gradient-to-br from-green-50 to-green-100 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-                <div class="w-16 h-16 bg-green-600 rounded-full flex items-center justify-center mb-4">
-                    <i class="fas fa-book text-white text-2xl"></i>
-                </div>
-                <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Learn Together</h3>
-                <p class="text-sm md:text-base text-gray-700">Participate in book clubs, workshops, and study sessions with experts and fellow learners.</p>
-            </div>
-            <div class="bg-gradient-to-br from-purple-50 to-purple-100 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-                <div class="w-16 h-16 bg-purple-600 rounded-full flex items-center justify-center mb-4">
-                    <i class="fas fa-rocket text-white text-2xl"></i>
-                </div>
-                <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Cloud Native</h3>
-                <p class="text-sm md:text-base text-gray-700">Master cloud-native architectures, microservices, and cutting-edge development practices.</p>
-            </div>
+<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
+        <div class="w-16 h-16 bg-[#b20738] rounded-full flex items-center justify-center mb-4">
+          <i class="fas fa-users text-white text-2xl"></i>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Community Driven</h3>
+        <p class="text-sm md:text-base text-gray-700">Join a vibrant community of developers passionate about Quarkus and modern Java development.</p>
+      </div>
+<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
+        <div class="w-16 h-16 bg-[#333333] rounded-full flex items-center justify-center mb-4">
+          <i class="fas fa-book text-white text-2xl"></i>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Learn Together</h3>
+        <p class="text-sm md:text-base text-gray-700">Participate in book clubs, workshops, and study sessions with experts and fellow learners.</p>
+      </div>
+<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
+        <div class="w-16 h-16 bg-[#888888] rounded-full flex items-center justify-center mb-4">
+          <i class="fas fa-rocket text-white text-2xl"></i>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Cloud Native</h3>
+        <p class="text-sm md:text-base text-gray-700">Master cloud-native architectures, microservices, and cutting-edge development practices.</p>
+      </div>
         </div>
     </section>
 
@@ -71,17 +71,17 @@ image: quarkusclub.jpg
         <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-gray-900 text-center">Explore QuarkusClub</h2>
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
             <a href="{site.url('/bookclub')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-book-reader text-3xl sm:text-4xl text-blue-600 mb-2 sm:mb-3"></i>
+                <i class="fas fa-book-reader text-3xl sm:text-4xl text-[#b20738] mb-2 sm:mb-3"></i>
                 <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">BookClub</h3>
                 <p class="text-sm text-gray-600 mt-2">Study books with authors</p>
             </a>
             <a href="{site.url('/events')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-calendar-alt text-3xl sm:text-4xl text-green-600 mb-2 sm:mb-3"></i>
+                <i class="fas fa-calendar-alt text-3xl sm:text-4xl text-[#333333] mb-2 sm:mb-3"></i>
                 <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">Events</h3>
                 <p class="text-sm text-gray-600 mt-2">Join our meetups</p>
             </a>
             <a href="{site.url('/about')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-info-circle text-3xl sm:text-4xl text-purple-600 mb-2 sm:mb-3"></i>
+                <i class="fas fa-info-circle text-3xl sm:text-4xl text-[#888888] mb-2 sm:mb-3"></i>
                 <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">About</h3>
                 <p class="text-sm text-gray-600 mt-2">Learn about us</p>
             </a>
@@ -105,7 +105,7 @@ image: quarkusclub.jpg
     <section class="mb-16 md:mb-20 pb-8">
         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 sm:mb-8 gap-4">
             <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900">Latest posts</h2>
-            <a href="{site.url('/posts')}" class="text-blue-600 hover:text-blue-800 font-semibold flex items-center gap-2 text-sm sm:text-base">
+            <a href="{site.url('/posts')}" class="text-[#b20738] hover:text-[#8a052c] font-semibold flex items-center gap-2 text-sm sm:text-base">
                 View all <i class="fas fa-arrow-right text-xs"></i>
             </a>
         </div>
@@ -120,7 +120,7 @@ image: quarkusclub.jpg
                 {/if}
                 <div class="p-4 sm:p-6">
                     <h3 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-                        <a href="{post.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{post.title}</a>
+                        <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
                     </h3>
                     {#if post.description??}
                     <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
@@ -128,7 +128,7 @@ image: quarkusclub.jpg
                     <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
                         {#if post.date??}
                         <span class="flex items-center gap-1 whitespace-nowrap">
-                            <i class="fa fa-calendar text-blue-600 text-xs"></i>
+                            <i class="fa fa-calendar text-[#b20738] text-xs"></i>
                             {post.date.format(global:ONLY_DATE_FORMAT)}
                         </span>
                         {/if}

--- a/templates/layouts/index.html
+++ b/templates/layouts/index.html
@@ -6,35 +6,36 @@ image: quarkusclub.jpg
 ---
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <!-- Hero Section -->
-    <section class="relative py-12 sm:py-16 md:py-20 mb-12 md:mb-16 overflow-hidden">
-        <div class="absolute inset-0 bg-black rounded-b-2xl"></div>
-        <div class="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmYiIGZpbGwtb3BhY2l0eT0iMC4xIj48cGF0aCBkPSJNMzYgMzRjMC0yLjIxLTEuNzktNC00LTRzLTQgMS43OS00IDQgMS43OSA0IDQgNCA0LTEuNzkgNC00em0wLTEwYzAtMi4yMS0xLjc5LTQtNC00cy00IDEuNzktNCA0IDEuNzkgNCA0IDQgNC0xLjc5IDQtNHptMC0xMGMwLTIuMjEtMS43OS00LTQtNHMtNCAxLjc5LTQgNCAxLjc5IDQgNCA0IDQtMS43OSA0LTR6Ii8+PC9nPjwvZz48L3N2Zz4=')] opacity-20"></div>
+    <section class="relative py-16 sm:py-20 md:py-28 mb-12 md:mb-16 overflow-hidden">
+        <div class="absolute inset-0 bg-black rounded-b-2xl border border-brand-red/30"></div>
+        <div class="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmYiIGZpbGwtb3BhY2l0eT0iMC4wNSI+PHBhdGggZD0iTTM2IDM0YzAtMi4yMS0xLjc5LTQtNC00cy00IDEuNzktNCA0IDEuNzkgNCA0IDQgNC0xLjc5IDQtNHptMC0xMGMwLTIuMjEtMS43OS00LTQtNHMtNCAxLjc5LTQgNCAxLjc5IDQgNCA0IDQtMS43OSA0LTR6bTAtMTBjMC0yLjIxLTEuNzktNC00LTRzLTQgMS43OS00IDQgMS43OSA0IDQgNCA0LTEuNzkgNC00eiIvPjwvZz48L2c+PC9zdmc+')] opacity-40"></div>
+        <div class="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-brand-red/10 to-transparent"></div>
         <div class="relative text-center text-white px-4 sm:px-6">
-            <div class="mb-4 sm:mb-6">
+            <div class="mb-6 sm:mb-8">
                 {#if page.image??}
-                <img src="{site.image('quarkusclub.jpeg')}" alt="{page.title}" class="w-24 h-24 sm:w-32 sm:h-32 mx-auto rounded-full border-4 border-white shadow-2xl"/>
+                <img src="{site.image('quarkusclub.jpeg')}" alt="{page.title}" class="w-28 h-28 sm:w-36 sm:h-36 mx-auto rounded-full border-4 border-brand-red shadow-2xl glow-red"/>
                 {/if}
             </div>
-            <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 drop-shadow-lg">{page.title}</h1>
+            <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold mb-4 sm:mb-6 drop-shadow-lg tracking-wider">{page.title}</h1>
             {#if page.description??}
-            <p class="text-base sm:text-lg md:text-xl lg:text-2xl max-w-3xl mx-auto mb-6 sm:mb-8 leading-relaxed">{page.description}</p>
+            <p class="text-base sm:text-lg md:text-xl lg:text-2xl max-w-3xl mx-auto mb-8 sm:mb-10 leading-relaxed text-gray-200">{page.description}</p>
             {/if}
             <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-3 sm:gap-4 mb-6 sm:mb-8">
-      {#if page.data('social-github')??}
-      <a href="https://github.com/{page.data('social-github')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-        <i class="fab fa-github mr-2"></i>GitHub
-      </a>
-      {/if}
-      {#if page.data('social-discord')??}
-      <a href="{page.data('social-discord')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-        <i class="fab fa-discord mr-2"></i>Discord
-      </a>
-      {/if}
-      {#if page.data('social-youtube')??}
-      <a href="{page.data('social-youtube')}" target="_blank" class="px-5 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg font-semibold hover:bg-gray-100 transition-all transform hover:scale-105 shadow-lg text-sm sm:text-base">
-        <i class="fab fa-youtube mr-2"></i>YouTube
-      </a>
-      {/if}
+                {#if page.data('social-github')??}
+                <a href="https://github.com/{page.data('social-github')}" target="_blank" class="inline-flex items-center gap-2 px-6 py-3 bg-surface-2 border border-border rounded-lg font-semibold text-sm sm:text-base hover:bg-brand-red hover:border-brand-red transition-all transform hover:scale-105 shadow-lg" style="color:#fff">
+                    <i class="fab fa-github"></i>GitHub
+                </a>
+                {/if}
+                {#if page.data('social-discord')??}
+                <a href="{page.data('social-discord')}" target="_blank" class="inline-flex items-center gap-2 px-6 py-3 bg-discord rounded-lg font-semibold text-sm sm:text-base hover:bg-discord-dark transition-all transform hover:scale-105 shadow-lg" style="color:#fff">
+                    <i class="fab fa-discord"></i>Discord
+                </a>
+                {/if}
+                {#if page.data('social-youtube')??}
+                <a href="{page.data('social-youtube')}" target="_blank" class="inline-flex items-center gap-2 px-6 py-3 bg-brand-red rounded-lg font-semibold text-sm sm:text-base hover:bg-brand-red-light transition-all transform hover:scale-105 shadow-lg glow-red" style="color:#fff">
+                    <i class="fab fa-youtube"></i>YouTube
+                </a>
+                {/if}
             </div>
         </div>
     </section>
@@ -42,54 +43,57 @@ image: quarkusclub.jpg
     <!-- Features Section -->
     <section class="mb-12 md:mb-16">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
-<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-        <div class="w-16 h-16 bg-[#b20738] rounded-full flex items-center justify-center mb-4">
-          <i class="fas fa-users text-white text-2xl"></i>
-        </div>
-        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Community Driven</h3>
-        <p class="text-sm md:text-base text-gray-700">Join a vibrant community of developers passionate about Quarkus and modern Java development.</p>
-      </div>
-<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-        <div class="w-16 h-16 bg-[#333333] rounded-full flex items-center justify-center mb-4">
-          <i class="fas fa-book text-white text-2xl"></i>
-        </div>
-        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Learn Together</h3>
-        <p class="text-sm md:text-base text-gray-700">Participate in book clubs, workshops, and study sessions with experts and fellow learners.</p>
-      </div>
-<div class="bg-gradient-to-br from-gray-100 to-gray-200 p-6 md:p-8 rounded-xl shadow-md hover:shadow-xl transition-shadow">
-        <div class="w-16 h-16 bg-[#888888] rounded-full flex items-center justify-center mb-4">
-          <i class="fas fa-rocket text-white text-2xl"></i>
-        </div>
-        <h3 class="text-xl md:text-2xl font-bold mb-3 text-gray-900">Cloud Native</h3>
-        <p class="text-sm md:text-base text-gray-700">Master cloud-native architectures, microservices, and cutting-edge development practices.</p>
-      </div>
+            <div class="bg-gradient-to-br from-surface-1 to-surface-2 p-6 md:p-8 rounded-xl border border-border hover:border-brand-red transition-all glow-red-hover group">
+                <div class="w-14 h-14 bg-brand-red rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 transition-transform">
+                    <i class="fas fa-users text-white text-xl"></i>
+                </div>
+                <h3 class="text-xl md:text-2xl font-bold mb-3 text-text-primary">Community Driven</h3>
+                <p class="text-sm md:text-base text-text-secondary">Join a vibrant community of developers passionate about Quarkus and modern Java development.</p>
+            </div>
+            <div class="bg-gradient-to-br from-surface-1 to-surface-2 p-6 md:p-8 rounded-xl border border-border hover:border-accent-warm transition-all group">
+                <div class="w-14 h-14 bg-accent-warm rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 transition-transform">
+                    <i class="fas fa-book text-white text-xl"></i>
+                </div>
+                <h3 class="text-xl md:text-2xl font-bold mb-3 text-text-primary">Learn Together</h3>
+                <p class="text-sm md:text-base text-text-secondary">Participate in book clubs, workshops, and study sessions with experts and fellow learners.</p>
+            </div>
+            <div class="bg-gradient-to-br from-surface-1 to-surface-2 p-6 md:p-8 rounded-xl border border-border hover:border-accent-cool transition-all group">
+                <div class="w-14 h-14 bg-accent-cool rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 transition-transform">
+                    <i class="fas fa-rocket text-white text-xl"></i>
+                </div>
+                <h3 class="text-xl md:text-2xl font-bold mb-3 text-text-primary">Cloud Native</h3>
+                <p class="text-sm md:text-base text-text-secondary">Master cloud-native architectures, microservices, and cutting-edge development practices.</p>
+            </div>
         </div>
     </section>
 
     <!-- Quick Links Section -->
-    <section class="mb-12 md:mb-16 bg-gradient-to-r from-gray-50 to-gray-100 p-6 md:p-8 rounded-xl">
-        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-gray-900 text-center">Explore QuarkusClub</h2>
+    <section class="mb-12 md:mb-16 bg-gradient-to-br from-surface-1 to-surface-2 p-6 md:p-8 rounded-xl border border-border">
+        <div class="flex items-center gap-3 mb-6 justify-center">
+            <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+            <h2 class="text-3xl sm:text-4xl font-bold text-text-primary m-0! tracking-wider">EXPLORE QUARKUSCLUB</h2>
+        </div>
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-            <a href="{site.url('/bookclub')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-book-reader text-3xl sm:text-4xl text-[#b20738] mb-2 sm:mb-3"></i>
-                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">BookClub</h3>
-                <p class="text-sm text-gray-600 mt-2">Study books with authors</p>
+            <a href="{site.url('/bookclub')}" class="bg-surface-2 p-4 sm:p-6 rounded-lg border border-border hover:border-brand-red-light hover:bg-surface-3 transition-all transform hover:scale-105 text-center">
+                <i class="fas fa-book-reader text-3xl sm:text-4xl text-brand-red mb-2 sm:mb-3"></i>
+                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-text-primary">BookClub</h3>
+                <p class="text-sm text-text-secondary mt-2">Study books with authors</p>
             </a>
-            <a href="{site.url('/events')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-calendar-alt text-3xl sm:text-4xl text-[#333333] mb-2 sm:mb-3"></i>
-                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">Events</h3>
-                <p class="text-sm text-gray-600 mt-2">Join our meetups</p>
+            <a href="{site.url('/events')}" class="bg-surface-2 p-4 sm:p-6 rounded-lg border border-border hover:border-accent-warm hover:bg-surface-3 transition-all transform hover:scale-105 text-center">
+                <i class="fas fa-calendar-alt text-3xl sm:text-4xl text-accent-warm mb-2 sm:mb-3"></i>
+                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-text-primary">Events</h3>
+                <p class="text-sm text-text-secondary mt-2">Join our meetups</p>
             </a>
-            <a href="{site.url('/about')}" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fas fa-info-circle text-3xl sm:text-4xl text-[#888888] mb-2 sm:mb-3"></i>
-                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">About</h3>
-                <p class="text-sm text-gray-600 mt-2">Learn about us</p>
+            <a href="{site.url('/about')}" class="bg-surface-2 p-4 sm:p-6 rounded-lg border border-border hover:border-accent-cool hover:bg-surface-3 transition-all transform hover:scale-105 text-center">
+                <i class="fas fa-info-circle text-3xl sm:text-4xl text-accent-cool mb-2 sm:mb-3"></i>
+                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-text-primary">About</h3>
+                <p class="text-sm text-text-secondary mt-2">Learn about us</p>
             </a>
             {#if page.data('social-youtube')??}
-            <a href="{page.data('social-youtube')}" target="_blank" class="bg-white p-4 sm:p-6 rounded-lg shadow hover:shadow-lg transition-all transform hover:scale-105 text-center">
-                <i class="fab fa-youtube text-3xl sm:text-4xl text-red-600 mb-2 sm:mb-3"></i>
-                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-gray-900">Videos</h3>
-                <p class="text-sm text-gray-600 mt-2">Watch our content</p>
+            <a href="{page.data('social-youtube')}" target="_blank" class="bg-surface-2 p-4 sm:p-6 rounded-lg border border-border hover:border-brand-red-light hover:bg-surface-3 transition-all transform hover:scale-105 text-center">
+                <i class="fab fa-youtube text-3xl sm:text-4xl text-brand-red mb-2 sm:mb-3"></i>
+                <h3 class="font-bold text-sm sm:text-base lg:text-lg text-text-primary">Videos</h3>
+                <p class="text-sm text-text-secondary mt-2">Watch our content</p>
             </a>
             {/if}
         </div>
@@ -104,36 +108,40 @@ image: quarkusclub.jpg
     {#insert featured-content}
     <section class="mb-16 md:mb-20 pb-8">
         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 sm:mb-8 gap-4">
-            <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900">Latest posts</h2>
-            <a href="{site.url('/posts')}" class="text-[#b20738] hover:text-[#8a052c] font-semibold flex items-center gap-2 text-sm sm:text-base">
-                View all <i class="fas fa-arrow-right text-xs"></i>
+            <div class="flex items-center gap-3">
+                <div class="w-1.5 h-8 bg-brand-red rounded"></div>
+                <h2 class="text-3xl sm:text-4xl md:text-5xl font-bold text-text-primary m-0! tracking-wider">LATEST POSTS</h2>
+            </div>
+            <a href="{site.url('/posts')}" class="text-brand-red hover:text-brand-red-light font-semibold flex items-center gap-2 text-sm sm:text-base group">
+                View all <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform"></i>
             </a>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
             {#for post in site.collections.posts}
             {#if post_count <= 6}
-            <article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group transform hover:-translate-y-1 duration-300">
+            <article class="bg-surface-1 rounded-xl border border-border hover:border-brand-red transition-all overflow-hidden group transform hover:-translate-y-1 duration-300 glow-red-hover">
                 {#if post.image??}
-                <div class="overflow-hidden h-40 sm:h-48">
-                    <img src="{post.image}" alt="{post.title}" class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"/>
+                <div class="overflow-hidden h-40 sm:h-48 relative">
+                    <img src="{post.image}" alt="{post.title}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"/>
+                    <div class="absolute inset-0 bg-gradient-to-t from-surface-1 via-transparent to-transparent"></div>
                 </div>
                 {/if}
                 <div class="p-4 sm:p-6">
                     <h3 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-                        <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
+                        <a href="{post.url}" class="text-text-primary hover:text-brand-red transition-colors">{post.title}</a>
                     </h3>
                     {#if post.description??}
-                    <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
+                    <p class="text-sm sm:text-base text-text-secondary mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
                     {/if}
-                    <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
+                    <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-text-muted">
                         {#if post.date??}
                         <span class="flex items-center gap-1 whitespace-nowrap">
-                            <i class="fa fa-calendar text-[#b20738] text-xs"></i>
+                            <i class="fa fa-calendar text-brand-red text-xs"></i>
                             {post.date.format(global:ONLY_DATE_FORMAT)}
                         </span>
                         {/if}
                         <span class="flex items-center gap-1 whitespace-nowrap">
-                            <i class="fa fa-clock text-green-600 text-xs"></i>
+                            <i class="fa fa-clock text-brand-red/60 text-xs"></i>
                             {post.readTime} min read
                         </span>
                         {#if post.data("language") == "pt-BR"}

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -6,13 +6,13 @@ layout: default
         <div class="container mx-auto px-4 py-4">
             <div class="flex items-center justify-between">
                 <div class="flex-shrink-0">
-                    <a href="{site.url}" class="text-xl md:text-2xl font-bold hover:text-blue-400 transition-colors">
+                    <a href="{site.url}" class="text-xl md:text-2xl font-bold hover:text-[#d41a4a] transition-colors">
                         {site.title}
                     </a>
                 </div>
                 
                 <!-- Mobile Menu Button -->
-                <button id="mobile-menu-button" class="md:hidden text-white hover:text-blue-400 focus:outline-none" aria-label="Toggle menu">
+                <button id="mobile-menu-button" class="md:hidden text-white hover:text-[#d41a4a] focus:outline-none" aria-label="Toggle menu">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
@@ -29,7 +29,7 @@ layout: default
                 <ul class="flex flex-col gap-3">
                     {#for item in cdi:menu.items}
                     <li>
-                        <a href="{item.path}" class="block text-white hover:text-blue-400 transition-colors py-2 {#if page.url.path == item.path}text-blue-400 font-semibold{/if}">
+                        <a href="{item.path}" class="block text-white hover:text-[#d41a4a] transition-colors py-2 {#if page.url.path == item.path}text-[#b20738] font-semibold{/if}">
                             {item.title}
                         </a>
                     </li>

--- a/templates/layouts/main.html
+++ b/templates/layouts/main.html
@@ -2,34 +2,31 @@
 layout: default
 ---
 <div class="min-h-screen flex flex-col">
-    <header class="bg-gray-900 text-white shadow-lg sticky top-0 z-50">
+    <header class="bg-surface-1 text-text-primary border-b border-border sticky top-0 z-50">
         <div class="container mx-auto px-4 py-4">
             <div class="flex items-center justify-between">
                 <div class="flex-shrink-0">
-                    <a href="{site.url}" class="text-xl md:text-2xl font-bold hover:text-[#d41a4a] transition-colors">
+                    <a href="{site.url}" class="text-xl md:text-2xl font-bold hover:text-brand-red-light transition-colors font-display tracking-wider">
                         {site.title}
                     </a>
                 </div>
-                
-                <!-- Mobile Menu Button -->
-                <button id="mobile-menu-button" class="md:hidden text-white hover:text-[#d41a4a] focus:outline-none" aria-label="Toggle menu">
+
+                <button id="mobile-menu-button" class="md:hidden text-text-primary hover:text-brand-red-light focus:outline-none" aria-label="Toggle menu">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                     </svg>
                 </button>
-                
-                <!-- Desktop Navigation -->
+
                 <nav class="hidden md:block">
                     {#include partials/navigation /}
                 </nav>
             </div>
-            
-            <!-- Mobile Navigation -->
-            <nav id="mobile-menu" class="hidden md:hidden mt-4 pb-4 border-t border-gray-700 pt-4">
+
+            <nav id="mobile-menu" class="hidden md:hidden mt-4 pb-4 border-t border-border pt-4">
                 <ul class="flex flex-col gap-3">
                     {#for item in cdi:menu.items}
                     <li>
-                        <a href="{item.path}" class="block text-white hover:text-[#d41a4a] transition-colors py-2 {#if page.url.path == item.path}text-[#b20738] font-semibold{/if}">
+                        <a href="{item.path}" class="block text-text-primary hover:text-brand-red-light transition-colors py-2 {#if page.url.path == item.path}text-brand-red font-semibold{/if}">
                             {item.title}
                         </a>
                     </li>
@@ -38,17 +35,16 @@ layout: default
             </nav>
         </div>
     </header>
-    
+
     <main class="flex-grow w-full max-w-screen-2xl mx-auto px-3 sm:px-4 lg:px-6 py-8">
         {#insert /}
     </main>
-    
-    <footer class="bg-gray-900 text-white mt-auto">
+
+    <footer class="bg-surface-1 text-text-primary border-t border-border mt-auto">
         {#include partials/footer /}
     </footer>
-    
+
     <script>
-        // Mobile menu toggle
         document.getElementById('mobile-menu-button')?.addEventListener('click', function() {
             const menu = document.getElementById('mobile-menu');
             menu?.classList.toggle('hidden');

--- a/templates/layouts/page.html
+++ b/templates/layouts/page.html
@@ -2,12 +2,12 @@
 layout: main
 ---
 <article class="w-full max-w-none">
-    <div class="prose prose-lg max-w-none">
-        
-        <div class="bg-white rounded-lg shadow-sm p-4">
+    <div class="prose prose-lg prose-invert max-w-none">
+
+        <div class="bg-surface-1 rounded-lg border border-border p-4">
             {#insert /}
         </div>
-        
+
         <footer class="mt-8">
             {#insert page-footer}
             {/insert}

--- a/templates/layouts/post.html
+++ b/templates/layouts/post.html
@@ -13,7 +13,7 @@ layout: page
             <strong class="text-gray-700 mr-2">Tags:</strong>
             {#for tag in page.data.tags.asStrings}
             {#let tagSlug = tag.slugify}
-            <a href="{site.url('/posts/tag/', tagSlug)}" class="inline-block px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm hover:bg-blue-200 transition-colors mr-2 mb-2">
+            <a href="{site.url('/posts/tag/', tagSlug)}" class="inline-block px-3 py-1 bg-red-100 text-[#8a052c] rounded-full text-sm hover:bg-red-200 transition-colors mr-2 mb-2">
                 {tag}
             </a>
             {/for}

--- a/templates/layouts/post.html
+++ b/templates/layouts/post.html
@@ -5,31 +5,31 @@ layout: page
 
 <div>
     {#insert /}
-    
+
     {#insert article-end}
-    <div class="mt-8 p-6 bg-gray-50 rounded-lg">
+    <div class="mt-8 p-6 bg-brand-red/10 border-l-4 border-brand-red rounded-lg">
         {#if page.data.tags??}
         <div class="mb-4">
-            <strong class="text-gray-700 mr-2">Tags:</strong>
+            <strong class="text-text-primary mr-2">Tags:</strong>
             {#for tag in page.data.tags.asStrings}
             {#let tagSlug = tag.slugify}
-            <a href="{site.url('/posts/tag/', tagSlug)}" class="inline-block px-3 py-1 bg-red-100 text-[#8a052c] rounded-full text-sm hover:bg-red-200 transition-colors mr-2 mb-2">
+            <a href="{site.url('/posts/tag/', tagSlug)}" class="inline-block px-3 py-1 bg-brand-red/20 text-brand-red rounded-full text-sm hover:bg-brand-red/30 transition-colors mr-2 mb-2 border border-brand-red/30">
                 {tag}
             </a>
             {/for}
         </div>
         {/if}
-        
-        <div class="flex flex-wrap gap-4 text-sm text-gray-600">
+
+        <div class="flex flex-wrap gap-4 text-sm text-text-secondary">
             {#if page.data.author??}
             <div class="flex items-center gap-2">
-                <i class="fa fa-user"></i>
-                <strong>Author:</strong> {page.data.author}
+                <i class="fa fa-user text-brand-red"></i>
+                <strong class="text-text-primary">Author:</strong> {page.data.author}
             </div>
             {/if}
-            
+
             <div class="flex items-center gap-2">
-                <i class="fa fa-clock"></i>
+                <i class="fa fa-clock text-brand-red"></i>
                 {page.readTime} min read
             </div>
         </div>

--- a/templates/layouts/tag.html
+++ b/templates/layouts/tag.html
@@ -11,7 +11,7 @@ tagging: posts
     <div class="mb-12">
         <div class="flex items-center gap-3 mb-4">
             <a href="{site.url('/tags')}" 
-               class="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-2"
+               class="text-[#b20738] hover:text-[#8a052c] transition-colors flex items-center gap-2"
                aria-label="Back to all tags">
                 <i class="fas fa-arrow-left"></i>
                 <span class="text-sm font-semibold">Back to tags</span>

--- a/templates/layouts/tag.html
+++ b/templates/layouts/tag.html
@@ -3,36 +3,32 @@ layout: page
 paginate: true
 tagging: posts
 ---
-
 {@io.quarkiverse.roq.frontmatter.runtime.model.NormalPage page}
 
-<div class="max-w-7xl mx-auto">
-    <!-- Tag Header -->
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="mb-12">
         <div class="flex items-center gap-3 mb-4">
-            <a href="{site.url('/tags')}" 
-               class="text-[#b20738] hover:text-[#8a052c] transition-colors flex items-center gap-2"
+            <a href="{site.url('/tags')}"
+               class="text-brand-red hover:text-brand-red-light transition-colors flex items-center gap-2"
                aria-label="Back to all tags">
                 <i class="fas fa-arrow-left"></i>
                 <span class="text-sm font-semibold">Back to tags</span>
             </a>
         </div>
 
-        <p class="text-lg text-gray-600">
+        <p class="text-lg text-text-secondary">
             {#if paginator??}
             {paginator.total} {#if paginator.total == 1}post{#else}posts{/if} tagged with this topic
             {/if}
         </p>
     </div>
 
-    <!-- Posts Grid -->
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mb-12">
         {#for post in site.collections.get(page.data.tagCollection).paginated(page.paginator)}
         {#include tags/postCard post=post site=site /}
         {/for}
     </div>
 
-    <!-- Pagination -->
     {#if paginator??}
     <div class="mb-12">
         {#include partials/pagination /}

--- a/templates/partials/author-card.html
+++ b/templates/partials/author-card.html
@@ -17,7 +17,7 @@
         {/if}
         
         {#if profile??}
-        <a href="{profile}" target="_blank" class="text-blue-600 hover:text-blue-800 text-sm inline-flex items-center gap-1">
+        <a href="{profile}" target="_blank" class="text-[#b20738] hover:text-[#8a052c] text-sm inline-flex items-center gap-1">
             <i class="fa fa-external-link-alt"></i> View Profile
         </a>
         {/if}

--- a/templates/partials/author-card.html
+++ b/templates/partials/author-card.html
@@ -1,23 +1,23 @@
-<div class="flex gap-4 p-4 bg-gray-100 rounded-lg hover:shadow-md transition-shadow">
+<div class="flex gap-4 p-4 bg-surface-2 rounded-lg border border-border hover:border-brand-red transition-colors">
     <div class="flex-shrink-0">
         {#if avatar??}
         <img src="{avatar}" alt="{name}" class="w-20 h-20 rounded-full object-cover" />
         {#else}
-        <div class="w-20 h-20 rounded-full bg-gray-300 flex items-center justify-center text-gray-600 text-2xl">
+        <div class="w-20 h-20 rounded-full bg-surface-3 flex items-center justify-center text-text-muted text-2xl">
             <i class="fa fa-user"></i>
         </div>
         {/if}
     </div>
-    
+
     <div class="flex-1">
-        <h3 class="text-xl font-bold text-gray-900 mb-1">{name}</h3>
-        
+        <h3 class="text-xl font-bold text-text-primary mb-1">{name}</h3>
+
         {#if nickname??}
-        <p class="text-gray-600 text-sm mb-2">@{nickname}</p>
+        <p class="text-text-secondary text-sm mb-2">@{nickname}</p>
         {/if}
-        
+
         {#if profile??}
-        <a href="{profile}" target="_blank" class="text-[#b20738] hover:text-[#8a052c] text-sm inline-flex items-center gap-1">
+        <a href="{profile}" target="_blank" class="text-brand-red hover:text-brand-red-light text-sm inline-flex items-center gap-1">
             <i class="fa fa-external-link-alt"></i> View Profile
         </a>
         {/if}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -33,7 +33,7 @@
                     {#for item in cdi:menu.items}
                     <li>
                         <a href="{item.path}" class="text-gray-300 hover:text-white transition-colors flex items-center gap-2">
-                            <i class="fas fa-chevron-right text-xs text-blue-500"></i>
+                            <i class="fas fa-chevron-right text-xs text-[#b20738]"></i>
                             {item.title}
                         </a>
                     </li>
@@ -46,13 +46,13 @@
                 <ul class="space-y-2">
                     <li>
                         <a href="{site.url('/about')}" class="text-gray-300 hover:text-white transition-colors flex items-center gap-2">
-                            <i class="fas fa-chevron-right text-xs text-blue-500"></i>
+                            <i class="fas fa-chevron-right text-xs text-[#b20738]"></i>
                             About
                         </a>
                     </li>
                     <li>
                         <a href="https://quarkus.io" target="_blank" class="text-gray-300 hover:text-white transition-colors flex items-center gap-2">
-                            <i class="fas fa-chevron-right text-xs text-blue-500"></i>
+                            <i class="fas fa-chevron-right text-xs text-[#b20738]"></i>
                             QuarkusIO
                         </a>
                     </li>
@@ -92,8 +92,8 @@
                 &copy; {now.year} {site.title}. All rights reserved.
             </p>
             <p>
-                Powered by <a href="https://quarkiverse.github.io/quarkiverse-docs/quarkus-roq/dev/" target="_blank" class="text-blue-400 hover:text-blue-300 transition-colors">Roq</a>
-                and <a href="https://quarkus.io" target="_blank" class="text-blue-400 hover:text-blue-300 transition-colors">Quarkus</a>
+                Powered by <a href="https://quarkiverse.github.io/quarkiverse-docs/quarkus-roq/dev/" target="_blank" class="text-[#d41a4a] hover:text-[#d41a4a] transition-colors">Roq</a>
+                and <a href="https://quarkus.io" target="_blank" class="text-[#d41a4a] hover:text-[#d41a4a] transition-colors">Quarkus</a>
             </p>
         </div>
     </div>

--- a/templates/partials/navigation.html
+++ b/templates/partials/navigation.html
@@ -2,7 +2,7 @@
     <ul class="flex gap-6">
         {#for item in cdi:menu.items}
         <li>
-            <a href="{item.path}" class="text-white hover:text-blue-400 transition-colors {#if page.url.path == item.path}text-blue-400 font-semibold{/if}">
+            <a href="{item.path}" class="text-white hover:text-[#d41a4a] transition-colors {#if page.url.path == item.path}text-[#d41a4a] font-semibold{/if}">
                 {item.title}
             </a>
         </li>

--- a/templates/partials/navigation.html
+++ b/templates/partials/navigation.html
@@ -1,11 +1,11 @@
 <nav>
-    <ul class="flex gap-6">
-        {#for item in cdi:menu.items}
-        <li>
-            <a href="{item.path}" class="text-white hover:text-[#d41a4a] transition-colors {#if page.url.path == item.path}text-[#d41a4a] font-semibold{/if}">
-                {item.title}
-            </a>
-        </li>
-        {/for}
-    </ul>
+<ul class="flex gap-6">
+{#for item in cdi:menu.items}
+<li>
+<a href="{item.path}" class="text-text-secondary hover:text-brand-red-light transition-colors {#if page.url.path == item.path}text-brand-red font-semibold{/if}">
+{item.title}
+</a>
+</li>
+{/for}
+</ul>
 </nav>

--- a/templates/partials/post-card.html
+++ b/templates/partials/post-card.html
@@ -9,7 +9,7 @@
     {/if}
     <div class="p-4 sm:p-6">
         <h2 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-            <a href="{post.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{post.title}</a>
+            <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
         </h2>
         {#if post.description??}
         <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
@@ -17,7 +17,7 @@
         <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
             {#if post.date??}
             <span class="flex items-center gap-1 whitespace-nowrap">
-                <i class="fa fa-calendar text-blue-600 text-xs"></i>
+                <i class="fa fa-calendar text-[#b20738] text-xs"></i>
                 {post.date.format(global:FULL_DATE_FORMAT)}
             </span>
             {/if}

--- a/templates/partials/post-card.html
+++ b/templates/partials/post-card.html
@@ -1,28 +1,29 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage post}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 
-<article class="bg-white rounded-xl shadow-md hover:shadow-2xl transition-all overflow-hidden group transform hover:-translate-y-1 duration-300">
+<article class="bg-surface-1 rounded-xl border border-border hover:border-brand-red transition-all overflow-hidden group transform hover:-translate-y-1 duration-300 glow-red-hover">
     {#if post.image??}
-    <div class="overflow-hidden h-40 sm:h-48">
+    <div class="overflow-hidden h-40 sm:h-48 relative">
         <img src="{post.image}" alt="{post.title}" class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"/>
+        <div class="absolute inset-0 bg-gradient-to-t from-surface-1 via-transparent to-transparent"></div>
     </div>
     {/if}
     <div class="p-4 sm:p-6">
         <h2 class="text-lg sm:text-xl font-bold mb-2 sm:mb-3 line-clamp-2">
-            <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
+            <a href="{post.url}" class="text-text-primary hover:text-brand-red transition-colors">{post.title}</a>
         </h2>
         {#if post.description??}
-        <p class="text-sm sm:text-base text-gray-600 mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
+        <p class="text-sm sm:text-base text-text-secondary mb-3 sm:mb-4 line-clamp-3">{post.description}</p>
         {/if}
-        <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-gray-500">
+        <div class="flex flex-wrap gap-2 sm:gap-3 text-xs sm:text-sm text-text-muted">
             {#if post.date??}
             <span class="flex items-center gap-1 whitespace-nowrap">
-                <i class="fa fa-calendar text-[#b20738] text-xs"></i>
+                <i class="fa fa-calendar text-brand-red text-xs"></i>
                 {post.date.format(global:FULL_DATE_FORMAT)}
             </span>
             {/if}
             <span class="flex items-center gap-1 whitespace-nowrap">
-                <i class="fa fa-clock text-green-600 text-xs"></i>
+                <i class="fa fa-clock text-brand-red/60 text-xs"></i>
                 {post.readTime} min read
             </span>
         </div>

--- a/templates/tags/postCard.html
+++ b/templates/tags/postCard.html
@@ -1,13 +1,13 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage post}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 
-<article class="bg-white rounded border border-gray-200 hover:border-blue-400 hover:shadow-md transition-all duration-200">
+<article class="bg-white rounded border border-gray-200 hover:border-[#d41a4a] hover:shadow-md transition-all duration-200">
     <div class="p-3">
         <time class="text-xs text-gray-500 block mb-1" datetime="{post.date}">
             {post.date.format('MM-dd-yyyy')}
         </time>
         <h2 class="text-sm font-bold mb-1 line-clamp-2">
-            <a href="{post.url}" class="text-gray-900 hover:text-blue-600 transition-colors">{post.title}</a>
+            <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
         </h2>
         {#if post.description??}
         <p class="text-xs text-gray-600 line-clamp-2">{post.description}</p>

--- a/templates/tags/postCard.html
+++ b/templates/tags/postCard.html
@@ -1,16 +1,16 @@
 {@io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage post}
 {@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
 
-<article class="bg-white rounded border border-gray-200 hover:border-[#d41a4a] hover:shadow-md transition-all duration-200">
+<article class="bg-surface-1 rounded border-l-4 border-brand-red hover:border-brand-red-light hover:shadow-lg transition-all duration-200">
     <div class="p-3">
-        <time class="text-xs text-gray-500 block mb-1" datetime="{post.date}">
+        <time class="text-xs text-text-muted block mb-1" datetime="{post.date}">
             {post.date.format('MM-dd-yyyy')}
         </time>
         <h2 class="text-sm font-bold mb-1 line-clamp-2">
-            <a href="{post.url}" class="text-gray-900 hover:text-[#b20738] transition-colors">{post.title}</a>
+            <a href="{post.url}" class="text-text-primary hover:text-brand-red transition-colors">{post.title}</a>
         </h2>
         {#if post.description??}
-        <p class="text-xs text-gray-600 line-clamp-2">{post.description}</p>
+        <p class="text-xs text-text-secondary line-clamp-2">{post.description}</p>
         {/if}
     </div>
 </article>


### PR DESCRIPTION
Summary

Supplements the dark theme refactor with contrast and UX fixes:

    Fix hero buttons (GitHub, Discord, YouTube) text always rendering white
    Fix BookClub button underline caused by prose inheritance
    Replace low-opacity icon backgrounds with solid colored backgrounds on feature cards for better contrast
    Add brand-red border around hero section matching card components style
    Change hero description text from text-red-100 to text-gray-200 for improved readability
    Add gradient backgrounds to feature and quick-link sections for visual depth
    Add hover:bg-surface-3 feedback on quick link cards
    Fix Tailwind v4 cascade layer specificity issues with !important color overrides
    Ensure all buttons maintain white text on hover
    Move custom CSS into proper @layer blocks for Tailwind v4 compatibility

Relates to https://github.com/quarkusclub/quarkusclub.github.io/issues/123 (fonts), https://github.com/quarkusclub/quarkusclub.github.io/issues/125 (colors), https://github.com/quarkusclub/quarkusclub.github.io/issues/142 (event title color)

Closes: #123 
Closes: #125 
Closes: #142 

This was done by: @omatheusmesmo, I just adjusted it.

@omatheusmesmo : I jsut adjusted @matheusandre1 's work. :rofl: 